### PR TITLE
Fixes for get_tool_yml_from_gi.py

### DIFF
--- a/helper_scripts/get_tool_yml_from_gi.py
+++ b/helper_scripts/get_tool_yml_from_gi.py
@@ -85,6 +85,8 @@ class GiToToolYaml:
             if self.get_packages is False:
                 if repo["name"].startswith("package_"):
                     continue
+            repo["tool_shed"] = "https://" + repo["tool_shed"] + "/"
+            print repo
             filtered_repository_list.append(repo)
         return filtered_repository_list
 
@@ -129,7 +131,6 @@ class GiToToolYaml:
         tool_list = []
         for repo in filtered_repository_list:
             values = itemgetter(*required_fields)(repo)
-            values = (values[0], values[1], values[2], values[3], "https://"+values[4])
             tool_list.append(dict(zip(yaml_categories, values)))
         return tool_list
 

--- a/helper_scripts/get_tool_yml_from_gi.py
+++ b/helper_scripts/get_tool_yml_from_gi.py
@@ -86,7 +86,6 @@ class GiToToolYaml:
                 if repo["name"].startswith("package_"):
                     continue
             repo["tool_shed"] = "https://" + repo["tool_shed"] + "/"
-            print repo
             filtered_repository_list.append(repo)
         return filtered_repository_list
 

--- a/helper_scripts/get_tool_yml_from_gi.py
+++ b/helper_scripts/get_tool_yml_from_gi.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python
+
+## Example usage: python get_tool_yml_from_gi.py -g https://mississippi.snv.jussieu.fr/ -a <api_key> -o tools.yml
+
 from operator import itemgetter
 from argparse import ArgumentParser
 

--- a/helper_scripts/get_tool_yml_from_gi.py
+++ b/helper_scripts/get_tool_yml_from_gi.py
@@ -57,7 +57,7 @@ class GiToToolYaml:
                         tool_panel_section_id = tool["panel_section_id"]
                         split_repo_url = tool["id"].split("/repos/")
                         sub_dir = split_repo_url[1].split("/")
-                        tool_shed = split_repo_url[0]
+                        tool_shed = "https://" + split_repo_url[0] + "/"
                         owner = sub_dir[0]
                         name = sub_dir[1]
                         tool_panel_list_filtered.append(

--- a/helper_scripts/get_tool_yml_from_gi.py
+++ b/helper_scripts/get_tool_yml_from_gi.py
@@ -129,6 +129,7 @@ class GiToToolYaml:
         tool_list = []
         for repo in filtered_repository_list:
             values = itemgetter(*required_fields)(repo)
+            values = (values[0], values[1], values[2], values[3], "https://"+values[4])
             tool_list.append(dict(zip(yaml_categories, values)))
         return tool_list
 
@@ -162,8 +163,9 @@ class GiToToolYaml:
                 del tool["tool_panel_section_id"]
 
     def write_to_yaml(self):
+	tool_dict={"tools":self.filtered_tool_list}
         with open(self.output_file, "w") as output:
-            output.write(yaml.safe_dump(self.filtered_tool_list, default_flow_style=False))
+            output.write(yaml.safe_dump(tool_dict, default_flow_style=False))
 
 
 def _parse_cli_options():


### PR DESCRIPTION
With these, we are able to generate a yml containing all tools of a galaxy instance.
The yml can then be used using https://github.com/galaxyproject/ansible-galaxy-tools