### PR TITLE
bump BlastParser_and_hits.xml to 2.3.2.

### DIFF
--- a/tools/msp_blastparser_and_hits/BlastParser_and_hits.py
+++ b/tools/msp_blastparser_and_hits/BlastParser_and_hits.py
@@ -15,8 +15,8 @@ def Parser():
     the_parser.add_argument('--flanking', action="store", type=int, help="number of flanking nucleotides added to the hit sequences") 
     the_parser.add_argument('--mode', action="store", choices=["verbose", "short"], type=str, help="reporting (verbose) or not reporting (short) oases contigs")
     the_parser.add_argument('--filter_relativeCov', action="store", type=float, default=0, help="filter out relative coverages below the specified ratio (float number)")
-    the_parser.add_argument('--filter_maxScore', action="store", type=float, default=0, help="filter out maximum BitScore below the specified float number")
-    the_parser.add_argument('--filter_meanScore', action="store", type=float, default=0, help="filter out maximum BitScore below the specified float number")
+    the_parser.add_argument('--filter_maxScore', action="store", type=float, default=0, help="filter out best BitScores below the specified float number")
+    the_parser.add_argument('--filter_meanScore', action="store", type=float, default=0, help="filter out mean BitScores below the specified float number")
     the_parser.add_argument('--al_sequences', action="store", type=str, help="sequences that have been blast aligned")
     the_parser.add_argument('--un_sequences', action="store", type=str, help="sequences that have not been blast aligned")
     args = the_parser.parse_args()
@@ -146,7 +146,7 @@ def outputParsing (F, Fasta, results, Xblastdict, fastadict, filter_relativeCov=
             print >> F, "# Suject Length: %s" % (results[subject]["subjectLength"])
             print >> F, "# Total Subject Coverage: %s" % (results[subject]["TotalCoverage"])
             print >> F, "# Relative Subject Coverage: %s" % (results[subject]["RelativeSubjectCoverage"])
-            print >> F, "# Maximum Bit Score: %s" % (results[subject]["maxBitScores"])
+            print >> F, "# Best Bit Score: %s" % (results[subject]["maxBitScores"])
             print >> F, "# Mean Bit Score: %s" % (results[subject]["meanBitScores"])
             for header in results[subject]["HitDic"]:
                 print >> Fasta, ">%s\n%s" % (header, insert_newlines(results[subject]["HitDic"][header]) )
@@ -161,7 +161,7 @@ def outputParsing (F, Fasta, results, Xblastdict, fastadict, filter_relativeCov=
                     info = "\t".join(info)
                     print >> F, info
     else:
-        print >>F, "# subject\tsubject length\tTotal Subject Coverage\tRelative Subject Coverage\tMaximum Bit Score\tMean Bit Score"
+        print >>F, "# subject\tsubject length\tTotal Subject Coverage\tRelative Subject Coverage\tBest Bit Score\tMean Bit Score"
         for subject in sorted (results, key=lambda x: results[x]["meanBitScores"], reverse=True):
             if results[subject]["RelativeSubjectCoverage"]<filter_relativeCov or results[subject]["maxBitScores"]<filter_maxScore or results[subject]["meanBitScores"]<filter_meanScore:
                 continue

--- a/tools/msp_blastparser_and_hits/BlastParser_and_hits.xml
+++ b/tools/msp_blastparser_and_hits/BlastParser_and_hits.xml
@@ -1,4 +1,4 @@
-<tool id="BlastParser_and_hits" name="Parse blast output and compile hits" version="2.3.1">
+<tool id="BlastParser_and_hits" name="Parse blast output and compile hits" version="2.3.2">
 <description>for virus discovery</description>
 <requirements></requirements>
 <command interpreter="python">
@@ -23,9 +23,9 @@ BlastParser_and_hits.py
 	<param name="sequences" type="data" format="fasta"  label="fasta sequences that have been blasted" />
 	<param name="blast" type="data" format="tabular" label="The blast output you wish to parse" />
 	<param name="flanking" type="text" size="5" value= "5" label="Number of flanking nucleotides to add to hits for CAP3 assembly"/>
-	<param name="mode" type="select" label="Verbose or short reporting mode" help="display or not the oases contigs">
-	    <option value="verbose" default="true">verbose</option>
-	    <option value="short">do not report oases contigs</option>
+	<param name="mode" type="select" label="Extensive or compact  reporting mode" help="display (extensive)  or not (compact) the oases contigs">
+	    <option value="verbose" default="true">extensive</option>
+	    <option value="short">compact</option>
 	</param>
     <conditional name="additional_filters">
             <param name="use_filters" type="select" label="Use Additional Filters?">

--- a/tools/msp_blastparser_and_hits/test-data/output.tab
+++ b/tools/msp_blastparser_and_hits/test-data/output.tab
@@ -5,7 +5,7 @@
 # Suject Length: 3005
 # Total Subject Coverage: 3001
 # Relative Subject Coverage: 0.998668885191
-# Maximum Bit Score: 5413.0
+# Best Bit Score: 5413.0
 # Mean Bit Score: 3241.5
 Locus_42_Transcript_2/2_Confidence_0.333_Length_597	100.0	593	2409	3001	99.2	0.0	1070.0
 Locus_42_Transcript_1/2_Confidence_0.333_Length_3138	100.0	3001	1	3001	95.6	0.0	5413.0
@@ -14,7 +14,7 @@ Locus_42_Transcript_1/2_Confidence_0.333_Length_3138	100.0	3001	1	3001	95.6	0.0	
 # Suject Length: 6780
 # Total Subject Coverage: 6765
 # Relative Subject Coverage: 0.997787610619
-# Maximum Bit Score: 8001.0
+# Best Bit Score: 8001.0
 # Mean Bit Score: 2184.97272727
 Locus_10_Transcript_7/8_Confidence_0.111_Length_255	100.0	26	6549	6524	9.8	0.001	48.2
 Locus_7_Transcript_10/11_Confidence_0.154_Length_4093	99.66	4093	542	4628	100.0	0.0	7319.0
@@ -43,7 +43,7 @@ Locus_7_Transcript_3/11_Confidence_0.154_Length_1743	99.89	1742	1716	3457	99.9	0
 # Suject Length: 6780
 # Total Subject Coverage: 6765
 # Relative Subject Coverage: 0.997787610619
-# Maximum Bit Score: 8001.0
+# Best Bit Score: 8001.0
 # Mean Bit Score: 2184.97272727
 Locus_10_Transcript_7/8_Confidence_0.111_Length_255	100.0	26	6549	6524	9.8	0.001	48.2
 Locus_7_Transcript_10/11_Confidence_0.154_Length_4093	99.66	4093	542	4628	100.0	0.0	7319.0
@@ -72,7 +72,7 @@ Locus_7_Transcript_3/11_Confidence_0.154_Length_1743	99.89	1742	1716	3457	99.9	0
 # Suject Length: 4806
 # Total Subject Coverage: 4708
 # Relative Subject Coverage: 0.979608822305
-# Maximum Bit Score: 5317.0
+# Best Bit Score: 5317.0
 # Mean Bit Score: 1797.4
 Locus_63_Transcript_1/1_Confidence_0.000_Length_371	95.96	371	3781	3411	99.7	3e-170	601.0
 Locus_42_Transcript_2/2_Confidence_0.333_Length_597	97.81	594	2761	3354	99.3	0.0	1012.0
@@ -84,7 +84,7 @@ Locus_42_Transcript_1/2_Confidence_0.333_Length_3138	97.61	3136	219	3354	99.9	0.
 # Suject Length: 4806
 # Total Subject Coverage: 4708
 # Relative Subject Coverage: 0.979608822305
-# Maximum Bit Score: 5317.0
+# Best Bit Score: 5317.0
 # Mean Bit Score: 1797.4
 Locus_63_Transcript_1/1_Confidence_0.000_Length_371	95.96	371	3781	3411	99.7	3e-170	601.0
 Locus_42_Transcript_2/2_Confidence_0.333_Length_597	97.81	594	2761	3354	99.3	0.0	1012.0
@@ -96,7 +96,7 @@ Locus_42_Transcript_1/2_Confidence_0.333_Length_3138	97.61	3136	219	3354	99.9	0.
 # Suject Length: 3014
 # Total Subject Coverage: 3004
 # Relative Subject Coverage: 0.996682149967
-# Maximum Bit Score: 2296.0
+# Best Bit Score: 2296.0
 # Mean Bit Score: 1733.0
 Locus_21_Transcript_1/1_Confidence_0.000_Length_919	100.0	919	813	1731	99.9	0.0	1658.0
 Locus_12_Transcript_1/1_Confidence_0.000_Length_1279	100.0	1273	3014	1742	99.5	0.0	2296.0
@@ -107,7 +107,7 @@ Locus_3_Transcript_4/5_Confidence_0.250_Length_926	100.0	825	825	1	89.0	0.0	1489
 # Suject Length: 3260
 # Total Subject Coverage: 3150
 # Relative Subject Coverage: 0.966257668712
-# Maximum Bit Score: 3952.0
+# Best Bit Score: 3952.0
 # Mean Bit Score: 1617.5
 Locus_15_Transcript_1/1_Confidence_0.000_Length_436	100.0	436	35	470	99.8	0.0	787.0
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	99.59	2217	972	3186	100.0	0.0	3952.0
@@ -120,7 +120,7 @@ Locus_16_Transcript_1/1_Confidence_0.000_Length_152	100.0	152	458	609	99.3	2e-72
 # Suject Length: 3243
 # Total Subject Coverage: 3016
 # Relative Subject Coverage: 0.930003083565
-# Maximum Bit Score: 1734.0
+# Best Bit Score: 1734.0
 # Mean Bit Score: 1205.8
 Locus_17_Transcript_3/3_Confidence_0.200_Length_456	98.9	456	1652	2107	99.8	0.0	800.0
 Locus_43_Transcript_1/1_Confidence_0.000_Length_1002	98.4	1003	2189	3191	99.9	0.0	1734.0
@@ -132,7 +132,7 @@ Locus_47_Transcript_1/1_Confidence_0.000_Length_940	99.26	940	674	1613	99.9	0.0	
 # Suject Length: 3243
 # Total Subject Coverage: 3016
 # Relative Subject Coverage: 0.930003083565
-# Maximum Bit Score: 1734.0
+# Best Bit Score: 1734.0
 # Mean Bit Score: 1205.8
 Locus_17_Transcript_3/3_Confidence_0.200_Length_456	98.9	456	1652	2107	99.8	0.0	800.0
 Locus_43_Transcript_1/1_Confidence_0.000_Length_1002	98.4	1003	2189	3191	99.9	0.0	1734.0
@@ -144,7 +144,7 @@ Locus_47_Transcript_1/1_Confidence_0.000_Length_940	99.26	940	674	1613	99.9	0.0	
 # Suject Length: 3360
 # Total Subject Coverage: 2526
 # Relative Subject Coverage: 0.751785714286
-# Maximum Bit Score: 978.0
+# Best Bit Score: 978.0
 # Mean Bit Score: 445.75
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	99.39	164	546	383	99.4	3e-77	291.0
 Locus_62_Transcript_1/1_Confidence_0.000_Length_130	98.46	130	1733	1862	99.2	8e-58	226.0
@@ -163,7 +163,7 @@ Locus_58_Transcript_2/2_Confidence_0.333_Length_368	99.69	323	2222	1900	87.5	3e-
 # Suject Length: 3360
 # Total Subject Coverage: 2526
 # Relative Subject Coverage: 0.751785714286
-# Maximum Bit Score: 978.0
+# Best Bit Score: 978.0
 # Mean Bit Score: 445.75
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	99.39	164	546	383	99.4	3e-77	291.0
 Locus_62_Transcript_1/1_Confidence_0.000_Length_130	98.46	130	1733	1862	99.2	8e-58	226.0
@@ -182,7 +182,7 @@ Locus_58_Transcript_2/2_Confidence_0.333_Length_368	99.69	323	2222	1900	87.5	3e-
 # Suject Length: 4743
 # Total Subject Coverage: 779
 # Relative Subject Coverage: 0.164242040902
-# Maximum Bit Score: 682.0
+# Best Bit Score: 682.0
 # Mean Bit Score: 390.742857143
 Locus_2_Transcript_4/5_Confidence_0.125_Length_605	85.4	596	184	779	98.3	0.0	682.0
 Locus_2_Transcript_5/5_Confidence_0.000_Length_447	82.99	435	345	779	97.1	4e-125	452.0
@@ -196,7 +196,7 @@ Locus_2_Transcript_3/5_Confidence_0.250_Length_207	100.0	26	209	184	12.1	7e-04	4
 # Suject Length: 3107
 # Total Subject Coverage: 2360
 # Relative Subject Coverage: 0.759575152881
-# Maximum Bit Score: 901.0
+# Best Bit Score: 901.0
 # Mean Bit Score: 281.591666667
 Locus_46_Transcript_1/1_Confidence_0.667_Length_178	98.31	178	2875	3052	99.4	4e-82	307.0
 Locus_72_Transcript_1/1_Confidence_0.000_Length_108	100.0	108	1903	1796	99.1	1e-48	196.0
@@ -227,7 +227,7 @@ Locus_1_Transcript_5/7_Confidence_0.231_Length_163	97.25	109	2944	3052	66.3	1e-4
 # Suject Length: 3107
 # Total Subject Coverage: 2359
 # Relative Subject Coverage: 0.759253299002
-# Maximum Bit Score: 856.0
+# Best Bit Score: 856.0
 # Mean Bit Score: 280.434782609
 Locus_46_Transcript_1/1_Confidence_0.667_Length_178	97.19	178	2875	3052	99.4	2e-79	298.0
 Locus_72_Transcript_1/1_Confidence_0.000_Length_108	99.07	108	1903	1796	99.1	4e-47	190.0
@@ -257,7 +257,7 @@ Locus_1_Transcript_5/7_Confidence_0.231_Length_163	96.33	109	2944	3052	66.3	1e-4
 # Suject Length: 3220
 # Total Subject Coverage: 2384
 # Relative Subject Coverage: 0.740372670807
-# Maximum Bit Score: 482.0
+# Best Bit Score: 482.0
 # Mean Bit Score: 269.6
 Locus_17_Transcript_3/3_Confidence_0.200_Length_456	73.2	459	1637	2091	99.6	4e-68	262.0
 Locus_43_Transcript_1/1_Confidence_0.000_Length_1002	70.31	458	2732	3183	44.4	2e-45	188.0
@@ -269,7 +269,7 @@ Locus_47_Transcript_1/1_Confidence_0.000_Length_940	72.01	904	707	1597	95.6	6e-1
 # Suject Length: 3220
 # Total Subject Coverage: 2390
 # Relative Subject Coverage: 0.742236024845
-# Maximum Bit Score: 457.0
+# Best Bit Score: 457.0
 # Mean Bit Score: 268.4
 Locus_17_Transcript_3/3_Confidence_0.200_Length_456	72.83	460	1642	2097	99.8	2e-67	260.0
 Locus_43_Transcript_1/1_Confidence_0.000_Length_1002	70.9	457	2738	3189	44.4	8e-50	203.0
@@ -281,7 +281,7 @@ Locus_47_Transcript_1/1_Confidence_0.000_Length_940	71.43	903	704	1603	95.6	2e-1
 # Suject Length: 3103
 # Total Subject Coverage: 2337
 # Relative Subject Coverage: 0.753142120529
-# Maximum Bit Score: 457.0
+# Best Bit Score: 457.0
 # Mean Bit Score: 262.6
 Locus_17_Transcript_3/3_Confidence_0.200_Length_456	72.83	460	1600	2055	99.8	2e-67	260.0
 Locus_43_Transcript_1/1_Confidence_0.000_Length_1002	70.3	404	2696	3094	39.3	4e-41	174.0
@@ -293,7 +293,7 @@ Locus_47_Transcript_1/1_Confidence_0.000_Length_940	71.43	903	662	1561	95.6	2e-1
 # Suject Length: 3107
 # Total Subject Coverage: 2355
 # Relative Subject Coverage: 0.757965883489
-# Maximum Bit Score: 756.0
+# Best Bit Score: 756.0
 # Mean Bit Score: 262.104347826
 Locus_46_Transcript_1/1_Confidence_0.667_Length_178	96.63	178	2875	3052	99.4	3e-78	295.0
 Locus_72_Transcript_1/1_Confidence_0.000_Length_108	93.52	108	1903	1796	99.1	6e-39	163.0
@@ -323,7 +323,7 @@ Locus_1_Transcript_5/7_Confidence_0.231_Length_163	95.41	109	2944	3052	66.3	6e-4
 # Suject Length: 1416
 # Total Subject Coverage: 1133
 # Relative Subject Coverage: 0.800141242938
-# Maximum Bit Score: 809.0
+# Best Bit Score: 809.0
 # Mean Bit Score: 259.0
 Locus_1_Transcript_1/7_Confidence_0.231_Length_224	98.47	196	517	712	87.1	9e-92	340.0
 Locus_56_Transcript_1/1_Confidence_0.000_Length_450	100.0	448	1231	784	99.3	0.0	809.0
@@ -343,7 +343,7 @@ Locus_1_Transcript_5/7_Confidence_0.231_Length_163	100.0	27	146	172	16.0	2e-04	5
 # Suject Length: 1383
 # Total Subject Coverage: 1035
 # Relative Subject Coverage: 0.748373101952
-# Maximum Bit Score: 740.0
+# Best Bit Score: 740.0
 # Mean Bit Score: 252.890909091
 Locus_1_Transcript_1/7_Confidence_0.231_Length_224	94.39	196	518	713	87.1	7e-81	304.0
 Locus_56_Transcript_1/1_Confidence_0.000_Length_450	96.44	450	1234	785	99.8	0.0	740.0
@@ -361,7 +361,7 @@ Locus_1_Transcript_2/7_Confidence_0.231_Length_143	91.45	117	597	713	81.1	7e-40	
 # Suject Length: 1365
 # Total Subject Coverage: 1054
 # Relative Subject Coverage: 0.772161172161
-# Maximum Bit Score: 771.0
+# Best Bit Score: 771.0
 # Mean Bit Score: 251.327272727
 Locus_1_Transcript_1/7_Confidence_0.231_Length_224	95.41	196	517	712	87.1	1e-83	313.0
 Locus_56_Transcript_1/1_Confidence_0.000_Length_450	98.0	450	1233	784	99.8	0.0	771.0
@@ -379,7 +379,7 @@ Locus_1_Transcript_2/7_Confidence_0.231_Length_143	92.31	117	596	712	81.1	6e-41	
 # Suject Length: 3106
 # Total Subject Coverage: 2356
 # Relative Subject Coverage: 0.758531873793
-# Maximum Bit Score: 630.0
+# Best Bit Score: 630.0
 # Mean Bit Score: 238.359090909
 Locus_46_Transcript_1/1_Confidence_0.667_Length_178	94.94	178	2874	3051	99.4	6e-74	280.0
 Locus_72_Transcript_1/1_Confidence_0.000_Length_108	89.62	106	1902	1797	97.2	2e-32	141.0
@@ -408,7 +408,7 @@ Locus_1_Transcript_5/7_Confidence_0.231_Length_163	95.37	108	2944	3051	65.6	2e-4
 # Suject Length: 3107
 # Total Subject Coverage: 2356
 # Relative Subject Coverage: 0.758287737367
-# Maximum Bit Score: 630.0
+# Best Bit Score: 630.0
 # Mean Bit Score: 237.922727273
 Locus_46_Transcript_1/1_Confidence_0.667_Length_178	94.94	178	2875	3052	99.4	6e-74	280.0
 Locus_72_Transcript_1/1_Confidence_0.000_Length_108	89.62	106	1903	1798	97.2	2e-32	141.0
@@ -437,7 +437,7 @@ Locus_1_Transcript_5/7_Confidence_0.231_Length_163	95.37	108	2945	3052	65.6	2e-4
 # Suject Length: 3254
 # Total Subject Coverage: 2251
 # Relative Subject Coverage: 0.69176398279
-# Maximum Bit Score: 480.0
+# Best Bit Score: 480.0
 # Mean Bit Score: 226.3
 Locus_17_Transcript_3/3_Confidence_0.200_Length_456	72.27	458	1659	2113	99.6	3e-64	250.0
 Locus_43_Transcript_1/1_Confidence_0.000_Length_1002	70.31	458	2754	3205	44.4	2e-44	185.0
@@ -450,7 +450,7 @@ Locus_47_Transcript_1/1_Confidence_0.000_Length_940	72.35	897	729	1618	94.6	2e-1
 # Suject Length: 3250
 # Total Subject Coverage: 2248
 # Relative Subject Coverage: 0.691692307692
-# Maximum Bit Score: 480.0
+# Best Bit Score: 480.0
 # Mean Bit Score: 224.5
 Locus_17_Transcript_3/3_Confidence_0.200_Length_456	72.27	458	1654	2108	99.6	3e-63	246.0
 Locus_43_Transcript_1/1_Confidence_0.000_Length_1002	70.52	458	2749	3200	44.4	2e-45	188.0
@@ -463,7 +463,7 @@ Locus_47_Transcript_1/1_Confidence_0.000_Length_940	72.35	897	724	1613	94.6	2e-1
 # Suject Length: 3250
 # Total Subject Coverage: 2248
 # Relative Subject Coverage: 0.691692307692
-# Maximum Bit Score: 480.0
+# Best Bit Score: 480.0
 # Mean Bit Score: 224.5
 Locus_17_Transcript_3/3_Confidence_0.200_Length_456	72.27	458	1654	2108	99.6	3e-63	246.0
 Locus_43_Transcript_1/1_Confidence_0.000_Length_1002	70.52	458	2749	3200	44.4	2e-45	188.0
@@ -476,7 +476,7 @@ Locus_47_Transcript_1/1_Confidence_0.000_Length_940	72.35	897	724	1613	94.6	2e-1
 # Suject Length: 1400
 # Total Subject Coverage: 1006
 # Relative Subject Coverage: 0.718571428571
-# Maximum Bit Score: 495.0
+# Best Bit Score: 495.0
 # Mean Bit Score: 222.133333333
 Locus_1_Transcript_1/7_Confidence_0.231_Length_224	89.18	194	518	711	86.2	3e-66	255.0
 Locus_56_Transcript_1/1_Confidence_0.000_Length_450	84.41	449	1233	785	99.6	4e-138	495.0
@@ -492,7 +492,7 @@ Locus_1_Transcript_2/7_Confidence_0.231_Length_143	83.48	115	597	711	79.7	3e-26	
 # Suject Length: 1399
 # Total Subject Coverage: 1008
 # Relative Subject Coverage: 0.720514653324
-# Maximum Bit Score: 342.0
+# Best Bit Score: 342.0
 # Mean Bit Score: 157.290909091
 Locus_1_Transcript_1/7_Confidence_0.231_Length_224	87.63	194	518	711	86.2	2e-62	242.0
 Locus_56_Transcript_1/1_Confidence_0.000_Length_450	77.16	451	1234	785	99.8	6e-92	342.0
@@ -510,7 +510,7 @@ Locus_1_Transcript_2/7_Confidence_0.231_Length_143	84.35	115	597	711	79.7	6e-28	
 # Suject Length: 3096
 # Total Subject Coverage: 2181
 # Relative Subject Coverage: 0.704457364341
-# Maximum Bit Score: 381.0
+# Best Bit Score: 381.0
 # Mean Bit Score: 151.023809524
 Locus_46_Transcript_1/1_Confidence_0.667_Length_178	80.45	179	2862	3039	99.4	5e-37	158.0
 Locus_72_Transcript_1/1_Confidence_0.000_Length_108	75.96	104	1888	1785	95.4	2e-12	75.2
@@ -538,7 +538,7 @@ Locus_1_Transcript_5/7_Confidence_0.231_Length_163	81.52	92	2949	3039	55.2	3e-14
 # Suject Length: 3096
 # Total Subject Coverage: 2181
 # Relative Subject Coverage: 0.704457364341
-# Maximum Bit Score: 381.0
+# Best Bit Score: 381.0
 # Mean Bit Score: 151.023809524
 Locus_46_Transcript_1/1_Confidence_0.667_Length_178	80.45	179	2862	3039	99.4	5e-37	158.0
 Locus_72_Transcript_1/1_Confidence_0.000_Length_108	75.96	104	1888	1785	95.4	2e-12	75.2
@@ -566,7 +566,7 @@ Locus_1_Transcript_5/7_Confidence_0.231_Length_163	81.52	92	2949	3039	55.2	3e-14
 # Suject Length: 389
 # Total Subject Coverage: 359
 # Relative Subject Coverage: 0.922879177378
-# Maximum Bit Score: 280.0
+# Best Bit Score: 280.0
 # Mean Bit Score: 150.366666667
 Locus_46_Transcript_1/1_Confidence_0.667_Length_178	94.94	178	157	334	99.4	6e-74	280.0
 Locus_82_Transcript_1/1_Confidence_1.000_Length_165	93.23	133	133	1	80.0	1e-49	199.0
@@ -585,7 +585,7 @@ Locus_1_Transcript_5/7_Confidence_0.231_Length_163	95.37	108	227	334	65.6	2e-41	
 # Suject Length: 7617
 # Total Subject Coverage: 2353
 # Relative Subject Coverage: 0.30891427071
-# Maximum Bit Score: 212.0
+# Best Bit Score: 212.0
 # Mean Bit Score: 146.552941176
 Locus_7_Transcript_10/11_Confidence_0.154_Length_4093	68.39	367	2487	2847	8.9	1e-28	134.0
 Locus_7_Transcript_10/11_Confidence_0.154_Length_4093	65.43	564	4482	5036	13.5	1e-22	114.0
@@ -609,7 +609,7 @@ Locus_7_Transcript_7/11_Confidence_0.462_Length_4481	65.43	564	4482	5036	12.4	2e
 # Suject Length: 7611
 # Total Subject Coverage: 2850
 # Relative Subject Coverage: 0.374458021285
-# Maximum Bit Score: 264.0
+# Best Bit Score: 264.0
 # Mean Bit Score: 141.735
 Locus_7_Transcript_10/11_Confidence_0.154_Length_4093	65.19	790	2481	3258	19.1	4e-36	159.0
 Locus_7_Transcript_10/11_Confidence_0.154_Length_4093	64.49	628	4416	5036	15.1	6e-21	109.0
@@ -636,7 +636,7 @@ Locus_7_Transcript_7/11_Confidence_0.462_Length_4481	64.49	628	4416	5036	13.8	6e
 # Suject Length: 3420
 # Total Subject Coverage: 1015
 # Relative Subject Coverage: 0.296783625731
-# Maximum Bit Score: 241.0
+# Best Bit Score: 241.0
 # Mean Bit Score: 141.442857143
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	77.61	134	536	404	80.5	1e-19	100.0
 Locus_62_Transcript_1/1_Confidence_0.000_Length_130	80.39	102	1723	1824	77.7	3e-18	95.1
@@ -650,7 +650,7 @@ Locus_58_Transcript_2/2_Confidence_0.333_Length_368	80.92	262	2154	1894	70.7	1e-
 # Suject Length: 3429
 # Total Subject Coverage: 1309
 # Relative Subject Coverage: 0.381743948673
-# Maximum Bit Score: 264.0
+# Best Bit Score: 264.0
 # Mean Bit Score: 135.325
 Locus_62_Transcript_1/1_Confidence_0.000_Length_130	85.71	77	1736	1812	58.5	1e-16	89.7
 Locus_65_Transcript_1/1_Confidence_0.000_Length_158	70.49	122	894	1015	76.6	3e-07	59.0
@@ -665,7 +665,7 @@ Locus_58_Transcript_2/2_Confidence_0.333_Length_368	81.99	272	2175	1906	73.1	1e-
 # Suject Length: 3427
 # Total Subject Coverage: 1309
 # Relative Subject Coverage: 0.381966734753
-# Maximum Bit Score: 264.0
+# Best Bit Score: 264.0
 # Mean Bit Score: 135.3125
 Locus_62_Transcript_1/1_Confidence_0.000_Length_130	85.71	77	1729	1805	58.5	1e-16	89.7
 Locus_65_Transcript_1/1_Confidence_0.000_Length_158	70.49	122	887	1008	76.6	3e-07	59.0
@@ -680,7 +680,7 @@ Locus_58_Transcript_2/2_Confidence_0.333_Length_368	81.99	272	2168	1899	73.1	1e-
 # Suject Length: 3427
 # Total Subject Coverage: 1309
 # Relative Subject Coverage: 0.381966734753
-# Maximum Bit Score: 264.0
+# Best Bit Score: 264.0
 # Mean Bit Score: 135.3125
 Locus_62_Transcript_1/1_Confidence_0.000_Length_130	85.71	77	1729	1805	58.5	1e-16	89.7
 Locus_65_Transcript_1/1_Confidence_0.000_Length_158	70.49	122	887	1008	76.6	3e-07	59.0
@@ -695,7 +695,7 @@ Locus_58_Transcript_2/2_Confidence_0.333_Length_368	81.99	272	2168	1899	73.1	1e-
 # Suject Length: 7611
 # Total Subject Coverage: 3998
 # Relative Subject Coverage: 0.525292340034
-# Maximum Bit Score: 266.0
+# Best Bit Score: 266.0
 # Mean Bit Score: 133.695
 Locus_7_Transcript_10/11_Confidence_0.154_Length_4093	62.65	2608	2481	5036	62.4	1e-42	181.0
 Locus_7_Transcript_5/11_Confidence_0.308_Length_4519	62.65	2608	2481	5036	56.5	1e-42	181.0
@@ -722,7 +722,7 @@ Locus_7_Transcript_7/11_Confidence_0.462_Length_4481	67.86	501	5481	5979	11.1	3e
 # Suject Length: 7611
 # Total Subject Coverage: 3998
 # Relative Subject Coverage: 0.525292340034
-# Maximum Bit Score: 266.0
+# Best Bit Score: 266.0
 # Mean Bit Score: 133.695
 Locus_7_Transcript_10/11_Confidence_0.154_Length_4093	62.65	2608	2481	5036	62.4	1e-42	181.0
 Locus_7_Transcript_5/11_Confidence_0.308_Length_4519	62.65	2608	2481	5036	56.5	1e-42	181.0
@@ -749,7 +749,7 @@ Locus_7_Transcript_7/11_Confidence_0.462_Length_4481	67.86	501	5481	5979	11.1	3e
 # Suject Length: 3418
 # Total Subject Coverage: 1257
 # Relative Subject Coverage: 0.367758923347
-# Maximum Bit Score: 255.0
+# Best Bit Score: 255.0
 # Mean Bit Score: 132.7125
 Locus_62_Transcript_1/1_Confidence_0.000_Length_130	87.01	77	1726	1802	58.5	3e-18	95.1
 Locus_65_Transcript_1/1_Confidence_0.000_Length_158	71.31	122	884	1005	76.6	2e-08	62.6
@@ -764,7 +764,7 @@ Locus_58_Transcript_2/2_Confidence_0.333_Length_368	81.25	272	2165	1896	73.1	5e-
 # Suject Length: 3571
 # Total Subject Coverage: 93
 # Relative Subject Coverage: 0.026043125175
-# Maximum Bit Score: 96.9
+# Best Bit Score: 96.9
 # Mean Bit Score: 96.9
 Locus_35_Transcript_1/1_Confidence_0.000_Length_166	83.87	93	150	58	54.8	1e-18	96.9
 #
@@ -772,7 +772,7 @@ Locus_35_Transcript_1/1_Confidence_0.000_Length_166	83.87	93	150	58	54.8	1e-18	9
 # Suject Length: 8226
 # Total Subject Coverage: 371
 # Relative Subject Coverage: 0.0451008995867
-# Maximum Bit Score: 93.3
+# Best Bit Score: 93.3
 # Mean Bit Score: 93.3
 Locus_10_Transcript_8/8_Confidence_0.000_Length_1134	67.02	376	7448	7078	32.6	1e-16	93.3
 Locus_10_Transcript_3/8_Confidence_0.222_Length_529	67.02	376	7448	7078	69.9	6e-17	93.3
@@ -784,7 +784,7 @@ Locus_10_Transcript_6/8_Confidence_0.333_Length_1121	67.02	376	7448	7078	33.0	1e
 # Suject Length: 7561
 # Total Subject Coverage: 371
 # Relative Subject Coverage: 0.049067583653
-# Maximum Bit Score: 93.3
+# Best Bit Score: 93.3
 # Mean Bit Score: 93.3
 Locus_10_Transcript_8/8_Confidence_0.000_Length_1134	67.02	376	6805	6435	32.6	1e-16	93.3
 Locus_10_Transcript_3/8_Confidence_0.222_Length_529	67.02	376	6805	6435	69.9	6e-17	93.3
@@ -796,7 +796,7 @@ Locus_10_Transcript_6/8_Confidence_0.333_Length_1121	67.02	376	6805	6435	33.0	1e
 # Suject Length: 8226
 # Total Subject Coverage: 371
 # Relative Subject Coverage: 0.0451008995867
-# Maximum Bit Score: 93.3
+# Best Bit Score: 93.3
 # Mean Bit Score: 93.3
 Locus_10_Transcript_8/8_Confidence_0.000_Length_1134	67.02	376	7448	7078	32.6	1e-16	93.3
 Locus_10_Transcript_3/8_Confidence_0.222_Length_529	67.02	376	7448	7078	69.9	6e-17	93.3
@@ -808,7 +808,7 @@ Locus_10_Transcript_6/8_Confidence_0.333_Length_1121	67.02	376	7448	7078	33.0	1e
 # Suject Length: 8226
 # Total Subject Coverage: 371
 # Relative Subject Coverage: 0.0451008995867
-# Maximum Bit Score: 93.3
+# Best Bit Score: 93.3
 # Mean Bit Score: 93.3
 Locus_10_Transcript_8/8_Confidence_0.000_Length_1134	67.02	376	7448	7078	32.6	1e-16	93.3
 Locus_10_Transcript_3/8_Confidence_0.222_Length_529	67.02	376	7448	7078	69.9	6e-17	93.3
@@ -820,7 +820,7 @@ Locus_10_Transcript_6/8_Confidence_0.333_Length_1121	67.02	376	7448	7078	33.0	1e
 # Suject Length: 8226
 # Total Subject Coverage: 371
 # Relative Subject Coverage: 0.0451008995867
-# Maximum Bit Score: 93.3
+# Best Bit Score: 93.3
 # Mean Bit Score: 93.3
 Locus_10_Transcript_8/8_Confidence_0.000_Length_1134	67.02	376	7448	7078	32.6	1e-16	93.3
 Locus_10_Transcript_3/8_Confidence_0.222_Length_529	67.02	376	7448	7078	69.9	6e-17	93.3
@@ -832,7 +832,7 @@ Locus_10_Transcript_6/8_Confidence_0.333_Length_1121	67.02	376	7448	7078	33.0	1e
 # Suject Length: 8226
 # Total Subject Coverage: 371
 # Relative Subject Coverage: 0.0451008995867
-# Maximum Bit Score: 93.3
+# Best Bit Score: 93.3
 # Mean Bit Score: 93.3
 Locus_10_Transcript_8/8_Confidence_0.000_Length_1134	67.02	376	7448	7078	32.6	1e-16	93.3
 Locus_10_Transcript_3/8_Confidence_0.222_Length_529	67.02	376	7448	7078	69.9	6e-17	93.3
@@ -844,7 +844,7 @@ Locus_10_Transcript_6/8_Confidence_0.333_Length_1121	67.02	376	7448	7078	33.0	1e
 # Suject Length: 8226
 # Total Subject Coverage: 371
 # Relative Subject Coverage: 0.0451008995867
-# Maximum Bit Score: 93.3
+# Best Bit Score: 93.3
 # Mean Bit Score: 93.3
 Locus_10_Transcript_8/8_Confidence_0.000_Length_1134	67.02	376	7448	7078	32.6	1e-16	93.3
 Locus_10_Transcript_3/8_Confidence_0.222_Length_529	67.02	376	7448	7078	69.9	6e-17	93.3
@@ -856,7 +856,7 @@ Locus_10_Transcript_6/8_Confidence_0.333_Length_1121	67.02	376	7448	7078	33.0	1e
 # Suject Length: 8230
 # Total Subject Coverage: 371
 # Relative Subject Coverage: 0.0450789793439
-# Maximum Bit Score: 87.8
+# Best Bit Score: 87.8
 # Mean Bit Score: 87.8
 Locus_10_Transcript_8/8_Confidence_0.000_Length_1134	66.76	376	7451	7081	32.6	5e-15	87.8
 Locus_10_Transcript_3/8_Confidence_0.222_Length_529	66.76	376	7451	7081	69.9	2e-15	87.8
@@ -868,7 +868,7 @@ Locus_10_Transcript_6/8_Confidence_0.333_Length_1121	66.76	376	7451	7081	33.0	5e
 # Suject Length: 7510
 # Total Subject Coverage: 568
 # Relative Subject Coverage: 0.0756324900133
-# Maximum Bit Score: 93.3
+# Best Bit Score: 93.3
 # Mean Bit Score: 74.2636363636
 Locus_7_Transcript_10/11_Confidence_0.154_Length_4093	74.7	83	3397	3479	2.0	1e-04	55.4
 Locus_7_Transcript_5/11_Confidence_0.308_Length_4519	74.7	83	3397	3479	1.8	1e-04	55.4
@@ -886,7 +886,7 @@ Locus_7_Transcript_7/11_Confidence_0.462_Length_4481	74.7	83	3397	3479	1.8	1e-04
 # Suject Length: 7510
 # Total Subject Coverage: 568
 # Relative Subject Coverage: 0.0756324900133
-# Maximum Bit Score: 93.3
+# Best Bit Score: 93.3
 # Mean Bit Score: 74.2636363636
 Locus_7_Transcript_10/11_Confidence_0.154_Length_4093	74.7	83	3397	3479	2.0	1e-04	55.4
 Locus_7_Transcript_5/11_Confidence_0.308_Length_4519	74.7	83	3397	3479	1.8	1e-04	55.4
@@ -904,7 +904,7 @@ Locus_7_Transcript_7/11_Confidence_0.462_Length_4481	74.7	83	3397	3479	1.8	1e-04
 # Suject Length: 9207
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.00890626697078
-# Maximum Bit Score: 68.0
+# Best Bit Score: 68.0
 # Mean Bit Score: 68.0
 Locus_17_Transcript_1/3_Confidence_0.400_Length_1889	78.05	82	6195	6276	4.3	8e-09	68.0
 Locus_17_Transcript_2/3_Confidence_0.400_Length_2274	78.05	82	6195	6276	3.6	1e-08	68.0
@@ -913,7 +913,7 @@ Locus_17_Transcript_2/3_Confidence_0.400_Length_2274	78.05	82	6195	6276	3.6	1e-0
 # Suject Length: 9862
 # Total Subject Coverage: 153
 # Relative Subject Coverage: 0.0155140945042
-# Maximum Bit Score: 62.6
+# Best Bit Score: 62.6
 # Mean Bit Score: 62.6
 Locus_36_Transcript_1/1_Confidence_0.000_Length_445	70.32	155	5424	5272	34.2	8e-08	62.6
 #
@@ -921,7 +921,7 @@ Locus_36_Transcript_1/1_Confidence_0.000_Length_445	70.32	155	5424	5272	34.2	8e-
 # Suject Length: 1305
 # Total Subject Coverage: 200
 # Relative Subject Coverage: 0.153256704981
-# Maximum Bit Score: 62.6
+# Best Bit Score: 62.6
 # Mean Bit Score: 62.6
 Locus_56_Transcript_1/1_Confidence_0.000_Length_450	67.82	202	1111	912	44.2	8e-08	62.6
 #
@@ -929,7 +929,7 @@ Locus_56_Transcript_1/1_Confidence_0.000_Length_450	67.82	202	1111	912	44.2	8e-0
 # Suject Length: 9532
 # Total Subject Coverage: 351
 # Relative Subject Coverage: 0.0368233319345
-# Maximum Bit Score: 62.6
+# Best Bit Score: 62.6
 # Mean Bit Score: 59.45
 Locus_30_Transcript_1/1_Confidence_0.000_Length_395	73.39	109	3223	3330	26.6	3e-06	57.2
 Locus_17_Transcript_1/3_Confidence_0.400_Length_1889	68.16	201	6262	6459	10.4	3e-07	62.6
@@ -940,7 +940,7 @@ Locus_29_Transcript_1/1_Confidence_0.000_Length_870	86.67	45	9124	9080	5.1	2e-05
 # Suject Length: 9538
 # Total Subject Coverage: 351
 # Relative Subject Coverage: 0.0368001677501
-# Maximum Bit Score: 62.6
+# Best Bit Score: 62.6
 # Mean Bit Score: 59.45
 Locus_30_Transcript_1/1_Confidence_0.000_Length_395	73.39	109	3225	3332	26.6	3e-06	57.2
 Locus_17_Transcript_1/3_Confidence_0.400_Length_1889	68.16	201	6264	6461	10.4	3e-07	62.6
@@ -951,7 +951,7 @@ Locus_29_Transcript_1/1_Confidence_0.000_Length_870	86.67	45	9126	9082	5.1	2e-05
 # Suject Length: 9822
 # Total Subject Coverage: 153
 # Relative Subject Coverage: 0.015577275504
-# Maximum Bit Score: 59.0
+# Best Bit Score: 59.0
 # Mean Bit Score: 59.0
 Locus_36_Transcript_1/1_Confidence_0.000_Length_445	69.68	155	5397	5245	34.2	9e-07	59.0
 #
@@ -959,7 +959,7 @@ Locus_36_Transcript_1/1_Confidence_0.000_Length_445	69.68	155	5397	5245	34.2	9e-
 # Suject Length: 9545
 # Total Subject Coverage: 596
 # Relative Subject Coverage: 0.0624410686223
-# Maximum Bit Score: 62.6
+# Best Bit Score: 62.6
 # Mean Bit Score: 57.65
 Locus_4_Transcript_5/5_Confidence_0.111_Length_956	69.83	116	4652	4767	12.0	3e-04	51.8
 Locus_17_Transcript_2/3_Confidence_0.400_Length_2274	68.16	201	6262	6459	8.7	4e-07	62.6
@@ -974,7 +974,7 @@ Locus_4_Transcript_4/5_Confidence_0.333_Length_1170	69.83	116	4652	4767	9.8	4e-0
 # Suject Length: 8278
 # Total Subject Coverage: 44
 # Relative Subject Coverage: 0.00531529354917
-# Maximum Bit Score: 57.2
+# Best Bit Score: 57.2
 # Mean Bit Score: 57.2
 Locus_70_Transcript_1/1_Confidence_0.000_Length_147	88.64	44	8238	8195	29.3	9e-07	57.2
 #
@@ -982,7 +982,7 @@ Locus_70_Transcript_1/1_Confidence_0.000_Length_147	88.64	44	8238	8195	29.3	9e-0
 # Suject Length: 9663
 # Total Subject Coverage: 241
 # Relative Subject Coverage: 0.0249404946704
-# Maximum Bit Score: 62.6
+# Best Bit Score: 62.6
 # Mean Bit Score: 57.2
 Locus_36_Transcript_1/1_Confidence_0.000_Length_445	70.32	155	5239	5087	34.2	8e-08	62.6
 Locus_29_Transcript_1/1_Confidence_0.000_Length_870	72.73	88	9248	9161	10.0	3e-04	51.8
@@ -991,7 +991,7 @@ Locus_29_Transcript_1/1_Confidence_0.000_Length_870	72.73	88	9248	9161	10.0	3e-0
 # Suject Length: 8550
 # Total Subject Coverage: 44
 # Relative Subject Coverage: 0.00514619883041
-# Maximum Bit Score: 57.2
+# Best Bit Score: 57.2
 # Mean Bit Score: 57.2
 Locus_70_Transcript_1/1_Confidence_0.000_Length_147	88.64	44	8510	8467	29.3	9e-07	57.2
 #
@@ -999,7 +999,7 @@ Locus_70_Transcript_1/1_Confidence_0.000_Length_147	88.64	44	8510	8467	29.3	9e-0
 # Suject Length: 10059
 # Total Subject Coverage: 34
 # Relative Subject Coverage: 0.00338005765981
-# Maximum Bit Score: 57.2
+# Best Bit Score: 57.2
 # Mean Bit Score: 57.2
 Locus_17_Transcript_1/3_Confidence_0.400_Length_1889	97.06	34	7002	7035	1.7	1e-05	57.2
 Locus_17_Transcript_2/3_Confidence_0.400_Length_2274	97.06	34	7002	7035	1.5	2e-05	57.2
@@ -1008,7 +1008,7 @@ Locus_17_Transcript_2/3_Confidence_0.400_Length_2274	97.06	34	7002	7035	1.5	2e-0
 # Suject Length: 9863
 # Total Subject Coverage: 241
 # Relative Subject Coverage: 0.0244347561594
-# Maximum Bit Score: 62.6
+# Best Bit Score: 62.6
 # Mean Bit Score: 57.2
 Locus_36_Transcript_1/1_Confidence_0.000_Length_445	70.32	155	5438	5286	34.2	8e-08	62.6
 Locus_29_Transcript_1/1_Confidence_0.000_Length_870	72.73	88	9447	9360	10.0	3e-04	51.8
@@ -1017,7 +1017,7 @@ Locus_29_Transcript_1/1_Confidence_0.000_Length_870	72.73	88	9447	9360	10.0	3e-0
 # Suject Length: 9776
 # Total Subject Coverage: 241
 # Relative Subject Coverage: 0.0246522094926
-# Maximum Bit Score: 62.6
+# Best Bit Score: 62.6
 # Mean Bit Score: 57.2
 Locus_36_Transcript_1/1_Confidence_0.000_Length_445	70.32	155	5352	5200	34.2	8e-08	62.6
 Locus_29_Transcript_1/1_Confidence_0.000_Length_870	72.73	88	9361	9274	10.0	3e-04	51.8
@@ -1026,7 +1026,7 @@ Locus_29_Transcript_1/1_Confidence_0.000_Length_870	72.73	88	9361	9274	10.0	3e-0
 # Suject Length: 8358
 # Total Subject Coverage: 44
 # Relative Subject Coverage: 0.00526441732472
-# Maximum Bit Score: 57.2
+# Best Bit Score: 57.2
 # Mean Bit Score: 57.2
 Locus_70_Transcript_1/1_Confidence_0.000_Length_147	88.64	44	8318	8275	29.3	9e-07	57.2
 #
@@ -1034,7 +1034,7 @@ Locus_70_Transcript_1/1_Confidence_0.000_Length_147	88.64	44	8318	8275	29.3	9e-0
 # Suject Length: 8550
 # Total Subject Coverage: 44
 # Relative Subject Coverage: 0.00514619883041
-# Maximum Bit Score: 57.2
+# Best Bit Score: 57.2
 # Mean Bit Score: 57.2
 Locus_70_Transcript_1/1_Confidence_0.000_Length_147	88.64	44	8510	8467	29.3	9e-07	57.2
 #
@@ -1042,7 +1042,7 @@ Locus_70_Transcript_1/1_Confidence_0.000_Length_147	88.64	44	8510	8467	29.3	9e-0
 # Suject Length: 9838
 # Total Subject Coverage: 241
 # Relative Subject Coverage: 0.024496848953
-# Maximum Bit Score: 62.6
+# Best Bit Score: 62.6
 # Mean Bit Score: 57.2
 Locus_36_Transcript_1/1_Confidence_0.000_Length_445	70.32	155	5439	5287	34.2	8e-08	62.6
 Locus_29_Transcript_1/1_Confidence_0.000_Length_870	72.73	88	9448	9361	10.0	3e-04	51.8
@@ -1051,7 +1051,7 @@ Locus_29_Transcript_1/1_Confidence_0.000_Length_870	72.73	88	9448	9361	10.0	3e-0
 # Suject Length: 3191
 # Total Subject Coverage: 91
 # Relative Subject Coverage: 0.0285177060483
-# Maximum Bit Score: 57.2
+# Best Bit Score: 57.2
 # Mean Bit Score: 57.2
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.63	91	514	424	54.9	1e-06	57.2
 #
@@ -1059,7 +1059,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.63	91	514	424	54.9	1e-06	
 # Suject Length: 9536
 # Total Subject Coverage: 282
 # Relative Subject Coverage: 0.029572147651
-# Maximum Bit Score: 62.6
+# Best Bit Score: 62.6
 # Mean Bit Score: 55.85
 Locus_30_Transcript_1/1_Confidence_0.000_Length_395	74.76	103	3216	3315	25.8	7e-08	62.6
 Locus_17_Transcript_1/3_Confidence_0.400_Length_1889	70.21	141	6600	6736	7.2	5e-05	55.4
@@ -1070,7 +1070,7 @@ Locus_29_Transcript_1/1_Confidence_0.000_Length_870	84.44	45	9124	9080	5.1	0.001
 # Suject Length: 627
 # Total Subject Coverage: 40
 # Relative Subject Coverage: 0.0637958532695
-# Maximum Bit Score: 55.4
+# Best Bit Score: 55.4
 # Mean Bit Score: 55.4
 Locus_70_Transcript_1/1_Confidence_0.000_Length_147	90.0	40	627	588	26.5	3e-06	55.4
 #
@@ -1078,7 +1078,7 @@ Locus_70_Transcript_1/1_Confidence_0.000_Length_147	90.0	40	627	588	26.5	3e-06	5
 # Suject Length: 9940
 # Total Subject Coverage: 241
 # Relative Subject Coverage: 0.024245472837
-# Maximum Bit Score: 59.0
+# Best Bit Score: 59.0
 # Mean Bit Score: 55.4
 Locus_36_Transcript_1/1_Confidence_0.000_Length_445	69.68	155	5514	5362	34.2	9e-07	59.0
 Locus_29_Transcript_1/1_Confidence_0.000_Length_870	72.73	88	9523	9436	10.0	3e-04	51.8
@@ -1087,7 +1087,7 @@ Locus_29_Transcript_1/1_Confidence_0.000_Length_870	72.73	88	9523	9436	10.0	3e-0
 # Suject Length: 9815
 # Total Subject Coverage: 241
 # Relative Subject Coverage: 0.0245542536933
-# Maximum Bit Score: 59.0
+# Best Bit Score: 59.0
 # Mean Bit Score: 55.4
 Locus_36_Transcript_1/1_Confidence_0.000_Length_445	69.68	155	5416	5264	34.2	9e-07	59.0
 Locus_29_Transcript_1/1_Confidence_0.000_Length_870	72.73	88	9425	9338	10.0	3e-04	51.8
@@ -1096,7 +1096,7 @@ Locus_29_Transcript_1/1_Confidence_0.000_Length_870	72.73	88	9425	9338	10.0	3e-0
 # Suject Length: 104710
 # Total Subject Coverage: 42
 # Relative Subject Coverage: 0.000401107821603
-# Maximum Bit Score: 53.6
+# Best Bit Score: 53.6
 # Mean Bit Score: 53.6
 Locus_35_Transcript_1/1_Confidence_0.000_Length_166	88.1	42	20023	19982	24.7	1e-05	53.6
 #
@@ -1104,7 +1104,7 @@ Locus_35_Transcript_1/1_Confidence_0.000_Length_166	88.1	42	20023	19982	24.7	1e-
 # Suject Length: 3101
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0264430828765
-# Maximum Bit Score: 53.6
+# Best Bit Score: 53.6
 # Mean Bit Score: 53.6
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	74.39	82	468	387	49.4	1e-05	53.6
 #
@@ -1112,7 +1112,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	74.39	82	468	387	49.4	1e-05	
 # Suject Length: 3199
 # Total Subject Coverage: 79
 # Relative Subject Coverage: 0.0246952172554
-# Maximum Bit Score: 53.6
+# Best Bit Score: 53.6
 # Mean Bit Score: 53.6
 Locus_73_Transcript_1/1_Confidence_0.000_Length_164	74.68	79	1711	1789	47.6	1e-05	53.6
 #
@@ -1120,7 +1120,7 @@ Locus_73_Transcript_1/1_Confidence_0.000_Length_164	74.68	79	1711	1789	47.6	1e-0
 # Suject Length: 104710
 # Total Subject Coverage: 42
 # Relative Subject Coverage: 0.000401107821603
-# Maximum Bit Score: 53.6
+# Best Bit Score: 53.6
 # Mean Bit Score: 53.6
 Locus_35_Transcript_1/1_Confidence_0.000_Length_166	88.1	42	20023	19982	24.7	1e-05	53.6
 #
@@ -1128,7 +1128,7 @@ Locus_35_Transcript_1/1_Confidence_0.000_Length_166	88.1	42	20023	19982	24.7	1e-
 # Suject Length: 8392
 # Total Subject Coverage: 44
 # Relative Subject Coverage: 0.00524308865586
-# Maximum Bit Score: 53.6
+# Best Bit Score: 53.6
 # Mean Bit Score: 53.6
 Locus_70_Transcript_1/1_Confidence_0.000_Length_147	86.36	44	8364	8321	29.3	1e-05	53.6
 #
@@ -1136,7 +1136,7 @@ Locus_70_Transcript_1/1_Confidence_0.000_Length_147	86.36	44	8364	8321	29.3	1e-0
 # Suject Length: 3204
 # Total Subject Coverage: 64
 # Relative Subject Coverage: 0.019975031211
-# Maximum Bit Score: 53.6
+# Best Bit Score: 53.6
 # Mean Bit Score: 53.6
 Locus_49_Transcript_1/1_Confidence_0.000_Length_499	78.12	64	751	688	12.6	5e-05	53.6
 #
@@ -1144,7 +1144,7 @@ Locus_49_Transcript_1/1_Confidence_0.000_Length_499	78.12	64	751	688	12.6	5e-05	
 # Suject Length: 3097
 # Total Subject Coverage: 87
 # Relative Subject Coverage: 0.0280917016468
-# Maximum Bit Score: 53.6
+# Best Bit Score: 53.6
 # Mean Bit Score: 53.6
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	75.0	88	1211	1297	3.9	2e-04	53.6
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	75.0	88	1211	1297	12.6	6e-05	53.6
@@ -1153,7 +1153,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	75.0	88	1211	1297	12.6	6e-05	
 # Suject Length: 3204
 # Total Subject Coverage: 64
 # Relative Subject Coverage: 0.019975031211
-# Maximum Bit Score: 53.6
+# Best Bit Score: 53.6
 # Mean Bit Score: 53.6
 Locus_49_Transcript_1/1_Confidence_0.000_Length_499	78.12	64	751	688	12.6	5e-05	53.6
 #
@@ -1161,7 +1161,7 @@ Locus_49_Transcript_1/1_Confidence_0.000_Length_499	78.12	64	751	688	12.6	5e-05	
 # Suject Length: 3046
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0315167432699
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1141	1236	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1141	1236	14.0	2e-04	51.8
@@ -1170,7 +1170,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1141	1236	14.0	2e-04	
 # Suject Length: 1736
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0552995391705
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1162	1257	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	51.8
@@ -1179,7 +1179,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	
 # Suject Length: 3097
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0309977397481
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1162	1257	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	51.8
@@ -1188,7 +1188,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	
 # Suject Length: 2919
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.032887975334
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1044	1139	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1044	1139	14.0	2e-04	51.8
@@ -1197,7 +1197,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1044	1139	14.0	2e-04	
 # Suject Length: 3097
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0309977397481
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1162	1257	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	51.8
@@ -1206,7 +1206,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	
 # Suject Length: 3046
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0315167432699
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1141	1236	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1141	1236	14.0	2e-04	51.8
@@ -1215,7 +1215,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1141	1236	14.0	2e-04	
 # Suject Length: 3047
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0315063997374
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1142	1237	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1142	1237	14.0	2e-04	51.8
@@ -1224,7 +1224,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1142	1237	14.0	2e-04	
 # Suject Length: 3097
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0309977397481
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1162	1257	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	51.8
@@ -1233,7 +1233,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	
 # Suject Length: 3097
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0309977397481
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1162	1257	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	51.8
@@ -1242,7 +1242,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	
 # Suject Length: 3097
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0309977397481
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1162	1257	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	51.8
@@ -1251,7 +1251,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	
 # Suject Length: 3097
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0309977397481
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1162	1257	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	51.8
@@ -1260,7 +1260,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	
 # Suject Length: 3097
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0309977397481
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1162	1257	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	51.8
@@ -1269,7 +1269,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	
 # Suject Length: 3046
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0315167432699
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1141	1236	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1141	1236	14.0	2e-04	51.8
@@ -1278,7 +1278,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1141	1236	14.0	2e-04	
 # Suject Length: 3097
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0309977397481
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1162	1257	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	51.8
@@ -1287,7 +1287,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	
 # Suject Length: 2962
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0324105334234
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1066	1161	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1066	1161	14.0	2e-04	51.8
@@ -1296,7 +1296,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1066	1161	14.0	2e-04	
 # Suject Length: 3097
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0309977397481
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1162	1257	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	51.8
@@ -1305,7 +1305,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	
 # Suject Length: 3048
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0314960629921
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1139	1234	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1139	1234	14.0	2e-04	51.8
@@ -1314,7 +1314,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1139	1234	14.0	2e-04	
 # Suject Length: 3097
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0309977397481
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1162	1257	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	51.8
@@ -1323,7 +1323,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	
 # Suject Length: 3050
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0314754098361
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1141	1236	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1141	1236	14.0	2e-04	51.8
@@ -1332,7 +1332,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1141	1236	14.0	2e-04	
 # Suject Length: 3097
 # Total Subject Coverage: 96
 # Relative Subject Coverage: 0.0309977397481
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_9_Transcript_2/3_Confidence_0.333_Length_2216	73.2	97	1162	1257	4.3	7e-04	51.8
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	51.8
@@ -1341,7 +1341,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	73.2	97	1162	1257	14.0	2e-04	
 # Suject Length: 3054
 # Total Subject Coverage: 79
 # Relative Subject Coverage: 0.0258677144728
-# Maximum Bit Score: 51.8
+# Best Bit Score: 51.8
 # Mean Bit Score: 51.8
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	74.39	82	420	342	49.4	5e-05	51.8
 #
@@ -1349,7 +1349,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	74.39	82	420	342	49.4	5e-05	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1357,7 +1357,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3145
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0260731319555
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	512	431	49.4	2e-04	50.0
 #
@@ -1365,7 +1365,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	512	431	49.4	2e-04	
 # Suject Length: 3039
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0269825600526
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1373,7 +1373,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1381,7 +1381,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3260
 # Total Subject Coverage: 87
 # Relative Subject Coverage: 0.0266871165644
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	72.41	87	543	457	52.4	2e-04	50.0
 #
@@ -1389,7 +1389,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	72.41	87	543	457	52.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1397,7 +1397,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3260
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0251533742331
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	50.0
 #
@@ -1405,7 +1405,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	
 # Suject Length: 3183
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0257618598806
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	537	456	49.4	2e-04	50.0
 #
@@ -1413,7 +1413,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	537	456	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1421,7 +1421,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3269
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0250841235852
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	539	458	49.4	2e-04	50.0
 #
@@ -1429,7 +1429,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	539	458	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1437,7 +1437,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3186
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0257376020088
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	546	465	49.4	2e-04	50.0
 #
@@ -1445,7 +1445,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	546	465	49.4	2e-04	
 # Suject Length: 3164
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0259165613148
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	417	336	49.4	2e-04	50.0
 #
@@ -1453,7 +1453,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	417	336	49.4	2e-04	
 # Suject Length: 3040
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0269736842105
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	409	328	49.4	2e-04	50.0
 #
@@ -1461,7 +1461,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	409	328	49.4	2e-04	
 # Suject Length: 3039
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0269825600526
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1469,7 +1469,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3163
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0259247549794
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	477	396	49.4	2e-04	50.0
 #
@@ -1477,7 +1477,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	477	396	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1485,7 +1485,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3184
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0257537688442
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	532	451	49.4	2e-04	50.0
 #
@@ -1493,7 +1493,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	532	451	49.4	2e-04	
 # Suject Length: 3163
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0259247549794
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	477	396	49.4	2e-04	50.0
 #
@@ -1501,7 +1501,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	477	396	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1509,7 +1509,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1517,7 +1517,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1525,7 +1525,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3056
 # Total Subject Coverage: 47
 # Relative Subject Coverage: 0.0153795811518
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_9_Transcript_1/3_Confidence_0.667_Length_681	82.98	47	1188	1234	6.8	8e-04	50.0
 #
@@ -1533,7 +1533,7 @@ Locus_9_Transcript_1/3_Confidence_0.667_Length_681	82.98	47	1188	1234	6.8	8e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1541,7 +1541,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3131
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0261897157458
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1549,7 +1549,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1557,7 +1557,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3179
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0257942749292
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	469	388	49.4	2e-04	50.0
 #
@@ -1565,7 +1565,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	469	388	49.4	2e-04	
 # Suject Length: 3259
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0251610923596
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	50.0
 #
@@ -1573,7 +1573,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	
 # Suject Length: 3260
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0251533742331
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	50.0
 #
@@ -1581,7 +1581,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1589,7 +1589,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3260
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0251533742331
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	50.0
 #
@@ -1597,7 +1597,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1605,7 +1605,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3198
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.025641025641
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	507	426	49.4	2e-04	50.0
 #
@@ -1613,7 +1613,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	507	426	49.4	2e-04	
 # Suject Length: 3039
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0269825600526
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1621,7 +1621,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1629,7 +1629,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3201
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0256169946892
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	508	427	49.4	2e-04	50.0
 #
@@ -1637,7 +1637,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	508	427	49.4	2e-04	
 # Suject Length: 3269
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0250841235852
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	539	458	49.4	2e-04	50.0
 #
@@ -1645,7 +1645,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	539	458	49.4	2e-04	
 # Suject Length: 3260
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0251533742331
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	50.0
 #
@@ -1653,7 +1653,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	
 # Suject Length: 3039
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0269825600526
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1661,7 +1661,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3261
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0251456608402
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	50.0
 #
@@ -1669,7 +1669,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	
 # Suject Length: 3260
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0251533742331
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	50.0
 #
@@ -1677,7 +1677,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	
 # Suject Length: 9226
 # Total Subject Coverage: 80
 # Relative Subject Coverage: 0.00867114675916
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_36_Transcript_1/1_Confidence_0.000_Length_445	73.75	80	4879	4800	17.8	5e-04	50.0
 #
@@ -1685,7 +1685,7 @@ Locus_36_Transcript_1/1_Confidence_0.000_Length_445	73.75	80	4879	4800	17.8	5e-0
 # Suject Length: 3039
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0269825600526
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1693,7 +1693,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3260
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0251533742331
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	50.0
 #
@@ -1701,7 +1701,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	
 # Suject Length: 3040
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0269736842105
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	409	328	49.4	2e-04	50.0
 #
@@ -1709,7 +1709,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	409	328	49.4	2e-04	
 # Suject Length: 3193
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0256811775759
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	539	458	49.4	2e-04	50.0
 #
@@ -1717,7 +1717,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	539	458	49.4	2e-04	
 # Suject Length: 3262
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0251379521766
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	50.0
 #
@@ -1725,7 +1725,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	
 # Suject Length: 3260
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0251533742331
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	50.0
 #
@@ -1733,7 +1733,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	
 # Suject Length: 3260
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0251533742331
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	50.0
 #
@@ -1741,7 +1741,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	538	457	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1749,7 +1749,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3084
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.026588845655
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	446	365	49.4	2e-04	50.0
 #
@@ -1757,7 +1757,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	446	365	49.4	2e-04	
 # Suject Length: 3039
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0269825600526
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1765,7 +1765,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3040
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0269736842105
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	409	328	49.4	2e-04	50.0
 #
@@ -1773,7 +1773,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	409	328	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1781,7 +1781,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1789,7 +1789,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3184
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0257537688442
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	532	451	49.4	2e-04	50.0
 #
@@ -1797,7 +1797,7 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	532	451	49.4	2e-04	
 # Suject Length: 1356
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0604719764012
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	50.0
 #
@@ -1805,6 +1805,6 @@ Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	408	327	49.4	2e-04	
 # Suject Length: 3085
 # Total Subject Coverage: 82
 # Relative Subject Coverage: 0.0265802269044
-# Maximum Bit Score: 50.0
+# Best Bit Score: 50.0
 # Mean Bit Score: 50.0
 Locus_69_Transcript_1/1_Confidence_0.000_Length_164	73.17	82	454	373	49.4	2e-04	50.0


### PR DESCRIPTION
Cosmetic changes in the xml form as well as in the python code. Field names in the tabular output are changed (Best instead of Maximum bit score). Changed accordingly in the test data. Test passed using planemo test