### PR TITLE
fetch_fasta_from_ncbi version 0.9.3

### DIFF
--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
@@ -166,7 +166,7 @@ class Eutils:
             try:
                 response = urllib2.urlopen(req)
                 fasta = response.read()
-                if "Resource temporarily unavailable" in fasta:
+                if ("Resource temporarily unavailable" in fasta) or (not fasta.startswith(">") ):
                     serverTransaction = False
                 else:
                     serverTransaction = True
@@ -176,8 +176,6 @@ class Eutils:
             except httplib.IncompleteRead as e:
                 serverTransaction = False
                 self.logger.info("IncompleteRead error:  %s" % ( e.partial ) )
-        if self.dbname != "pubmed":
-            assert fasta.startswith(">"), fasta
         fasta = self.sanitiser(self.dbname, fasta) #
         time.sleep(1)
         return fasta

--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.xml
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.xml
@@ -18,7 +18,6 @@
     <param name="dbname" type="select" label="NCBI database">
       <option value="nuccore">Nucleotide</option>
       <option value="protein">Protein</option>
-<!--      <option value="pubmed">Pubmed (experimental)</option> -->
     </param>
   </inputs>
   <outputs>

--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.xml
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.xml
@@ -1,4 +1,4 @@
-<tool id="retrieve_fasta_from_NCBI" name="Retrieve FASTA from NCBI" version="0.9.2">
+<tool id="retrieve_fasta_from_NCBI" name="Retrieve FASTA from NCBI" version="0.9.3">
   <description></description>
   <command interpreter="python">retrieve_fasta_from_NCBI.py -i "$queryString" -d $dbname -o $outfilename -l $logfile </command>
 


### PR DESCRIPTION
Polish the tool:
- bump to 0.9.3
- removing the experimental pubmed search which is not the purpose of the tool (yet I think it could be interesting to do text mining in galaxy)
- simplifying the test of fetched data integrity, in one single line test.
The version 0.9.3 has been tested on a huge download of nucleotide on mississippi. It is still running for proteins, but since 15 hours and it seems ok.