### PR TITLE
Cap3

### DIFF
--- a/tools/msp_cap3/.shed.yml
+++ b/tools/msp_cap3/.shed.yml
@@ -15,3 +15,4 @@ remote_repository_url: https://github.com/ARTbio/tools-artbio/tree/master/tools/
 toolshed:
   - https://lbcd41.snv.jussieu.fr/toolshed/
   - testtoolshed
+  - toolshed

--- a/tools/msp_cap3/cap3.xml
+++ b/tools/msp_cap3/cap3.xml
@@ -4,7 +4,7 @@
     	<requirement type="package" version="3">cap3</requirement>
     </requirements>
 <command>
-cap3 -o $overlaplength -p overlapidentity "$inputSequences" > "$cap3stdout";
+cap3 "$inputSequences" -o $overlaplength -p overlapidentity > "$cap3stdout";
                 mv "$inputSequences".cap.contigs $contigs;
                 mv "$inputSequences".cap.contigs.qual $contigsqual;
                 mv "$inputSequences".cap.contigs.links $contigslink;

--- a/tools/msp_cap3/cap3.xml
+++ b/tools/msp_cap3/cap3.xml
@@ -1,10 +1,10 @@
-<tool id="cap3" name="cap3" version="1.1.0">
+<tool id="cap3" name="cap3" version="1.2.0">
 <description>Sequence Assembly tool</description>
     <requirements>
     	<requirement type="package" version="3">cap3</requirement>
     </requirements>
 <command>
-cap3 "$inputSequences" > "$cap3stdout";
+cap3 -o $overlaplength -p overlapidentity "$inputSequences" > "$cap3stdout";
                 mv "$inputSequences".cap.contigs $contigs;
                 mv "$inputSequences".cap.contigs.qual $contigsqual;
                 mv "$inputSequences".cap.contigs.links $contigslink;
@@ -17,6 +17,8 @@ cap3 "$inputSequences" > "$cap3stdout";
 
         <inputs>
         	<param label="Input sequences to assemble" name="inputSequences" type="data" format="fasta" help="Input sequences to assemble" />
+        	<param label="specify overlap length cutoff > 15 (40)" name="overlaplength" type="integer" size="3" value="40" help="-o option. must be > 15. 40 by default" />
+        	<param label="specify overlap percent identity cutoff N > 65 (90)" name="overlapidentity" type="integer" size="3" value="90"  help="-p option. must be > 65. 90 by default" />
         </inputs>
 
 <outputs>
@@ -33,6 +35,8 @@ cap3 "$inputSequences" > "$cap3stdout";
   <tests>
     <test>
       <param name="inputSequences" value="input.fa" ftype="fasta"/>
+      <param name="overlaplength" value="40" />
+      <param name="overlapidentity" value="90" />
       <output name="contigsandsinglets" file="contigsandsinglets.fa"/>
       <output name="cap3stdout" file="cap3stdout.txt"/>
       <output name="contigs" file="contigs.fa"/>

--- a/tools/msp_cap3/cap3.xml
+++ b/tools/msp_cap3/cap3.xml
@@ -4,7 +4,7 @@
     	<requirement type="package" version="3">cap3</requirement>
     </requirements>
 <command>
-cap3 "$inputSequences" -o $overlaplength -p overlapidentity > "$cap3stdout";
+cap3 "$inputSequences" -o $overlaplength -p $overlapidentity > "$cap3stdout";
                 mv "$inputSequences".cap.contigs $contigs;
                 mv "$inputSequences".cap.contigs.qual $contigsqual;
                 mv "$inputSequences".cap.contigs.links $contigslink;


### PR DESCRIPTION
Introduced the possibility to tune -o and -p options in cap3. Not sure it helps a lot, but does not hurt. The bumped version has been pushed to the testtoolshed for testing in plastisipi, and its ok.
I have also modified the .shed.yml file with mention to toolshed in addition to the testtoolshed. The tool will have to be pushed to the main toolshed.