### PR TITLE
New version 1.1.0 of the msp_fasta_tabular_converter

### DIFF
--- a/tools/msp_fasta_tabular_converter/fasta_tabular_converter.py
+++ b/tools/msp_fasta_tabular_converter/fasta_tabular_converter.py
@@ -1,19 +1,37 @@
 #!/usr/bin/python
 #
 import sys
+import string
+import argparse
 from collections import defaultdict
 
-def readfasta_writetabular(fasta, tabular):
-  F = open(fasta, "r")
-  for line in F:
-    if line[0] == ">": continue
-    else:
-      seqdic[line[:-1]] += 1
-  F.close()
-  F = open(tabular, "w")
-  for seq in sorted(seqdic, key=seqdic.get, reverse=True):
-    print >> F, "%s\t%s" % (seq, seqdic[seq])
-  F.close()
+def Parser():
+    the_parser = argparse.ArgumentParser()
+    the_parser.add_argument(
+        '--input', action="store", type=str, help="input file")
+    the_parser.add_argument(
+        '--output', action="store", type=str, help="output converted file")
+    the_parser.add_argument(
+        '--type', action="store", type=str, help="type of convertion")
+    args = the_parser.parse_args()
+    return args
+
+def readfasta_writetabular(fasta, tabular, mode="oneline"):
+    F = open(fasta, "r")
+    for line in F:
+        if line[0] == ">":
+            try:
+                seqdic["".join(stringlist)] += 1 # to dump the sequence of the previous item - try because of first missing stringlist variable
+            except: pass
+            stringlist=[]
+        else:
+            stringlist.append(line[:-1])
+    seqdic["".join(stringlist)] +=  1 # for the last sequence
+    F.close()
+    F = open(tabular, "w")
+    for seq in sorted(seqdic, key=seqdic.get, reverse=True):
+        print >> F, "%s\t%s" % (seq, seqdic[seq])
+    F.close()
     
         
 def readtabular_writefasta(tabular, fasta):
@@ -72,17 +90,19 @@ def readfastaeighted_writefasta(fastaweigthed, fasta):
   F.close()
   Fw.close()
 
+def main(input, output, type):
+    if type == "fasta2tabular":
+        readfasta_writetabular(input, output)
+    elif type == "tabular2fasta":
+        readtabular_writefasta(input, output)
+    elif type == "tabular2fastaweight":
+        readtabular_writefastaweighted (input, output)
+    elif type == "fastaweight2fastaweight":
+        readfastaeighted_writefastaweighted(input, output)
+    elif type == "fastaweight2fasta":
+        readfastaeighted_writefasta(input, output)
 
-seqdic = defaultdict(int)
-option = sys.argv[3]
-
-if option == "fasta2tabular":
-  readfasta_writetabular(sys.argv[1], sys.argv[2])
-elif option == "tabular2fasta":
-  readtabular_writefasta(sys.argv[1], sys.argv[2])
-elif option == "tabular2fastaweight":
-  readtabular_writefastaweighted (sys.argv[1], sys.argv[2])
-elif option == "fastaweight2fastaweight":
-  readfastaeighted_writefastaweighted(sys.argv[1], sys.argv[2])
-elif option == "fastaweight2fasta":
-  readfastaeighted_writefasta(sys.argv[1], sys.argv[2])
+if __name__ == "__main__":
+    seqdic = defaultdict(int)
+    args = Parser()
+    main (args.input, args.output, args.type)

--- a/tools/msp_fasta_tabular_converter/fasta_tabular_converter.xml
+++ b/tools/msp_fasta_tabular_converter/fasta_tabular_converter.xml
@@ -1,6 +1,10 @@
-<tool id="fasta_tabular_converter" name="fasta - tabular" version="1.0.2">
+<tool id="fasta_tabular_converter" name="fasta - tabular" version="1.1.0">
   <description>conversions</description>
-  <command interpreter="python">fasta_tabular_converter.py $input $output $switch.conversionType</command>
+  <command interpreter="python">fasta_tabular_converter.py
+                                          --input $input
+                                          --output $output
+                                          --type $switch.conversionType
+  </command>
   <inputs>
     <conditional name="switch">
        <param name="conversionType" type="select" label="conversion option">
@@ -10,23 +14,22 @@
           <option value="fastaweight2fastaweight">recompile weighted fasta to catenated fasta weighted</option>
           <option value="fastaweight2fasta">fasta weighted to fasta</option>
        </param>
-    <when value="fasta2tabular">
-       <param name="input" type="data" format="fasta" label="fasta file to convert to tabular"/>
-    </when>
-    <when value="tabular2fasta">
-       <param name="input" type="data" format="tabular" label="tabular file to convert to fasta"/>
-    </when>
-    <when value="tabular2fastaweight">
-       <param name="input" type="data" format="tabular" label="tabular file to convert to fasta weighted"/>
-    </when>
-    <when value="fastaweight2fastaweight">
-       <param name="input" type="data" format="fasta" label="catenated fasta weighted to recompile" help="Use this option only if you known what you're doing"/>
-    </when>
-    <when value="fastaweight2fasta">
-       <param name="input" type="data" format="fasta" label="fasta weighted file to convert to fasta"/>
-    </when>
-   </conditional>
-
+       <when value="fasta2tabular">
+          <param name="input" type="data" format="fasta" label="fasta file to convert to tabular"/>
+       </when>
+       <when value="tabular2fasta">
+          <param name="input" type="data" format="tabular" label="tabular file to convert to fasta"/>
+       </when>
+       <when value="tabular2fastaweight">
+          <param name="input" type="data" format="tabular" label="tabular file to convert to fasta weighted"/>
+       </when>
+       <when value="fastaweight2fastaweight">
+          <param name="input" type="data" format="fasta" label="catenated fasta weighted to recompile" help="Use this option only if you known what you're doing"/>
+       </when>
+       <when value="fastaweight2fasta">
+          <param name="input" type="data" format="fasta" label="fasta weighted file to convert to fasta"/>
+       </when>
+    </conditional>
    </inputs>
 
  <outputs>
@@ -43,6 +46,7 @@
         <test>
             <param name="conversionType" value="fasta2tabular" />
             <param ftype="fasta" name="input" value="input.fa" />
+            <param name="lines" value="oneline" />
             <output file="output.tab" name="output" />
         </test>
         <test>

--- a/tools/msp_fasta_tabular_converter/fasta_tabular_converter.xml
+++ b/tools/msp_fasta_tabular_converter/fasta_tabular_converter.xml
@@ -46,7 +46,6 @@
         <test>
             <param name="conversionType" value="fasta2tabular" />
             <param ftype="fasta" name="input" value="input.fa" />
-            <param name="lines" value="oneline" />
             <output file="output.tab" name="output" />
         </test>
         <test>


### PR DESCRIPTION
Which takes into account multiline fasta file for the fasta to tabular conversion.
Note that multiline fasta are rewritten on single lines in the tabular output (otherwise, the output would not be tabular). See whether assembler may be affected by this after the reverse tabular 2 fasta conversion