### PR TITLE
Catch errors at retrieve from NCBI

### DIFF
--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
@@ -169,7 +169,7 @@ class Eutils:
             try:
                 response = urllib2.urlopen(req)
                 fasta = response.read()
-                if ("Resource temporarily unavailable" in fasta) or (not fasta.startswith(">") ):
+                if ("Resource temporarily unavailable" in fasta) or ("Error" in fasta) or (not fasta.startswith(">") ):
                     serverTransaction = False
                 else:
                     serverTransaction = True

--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
@@ -33,7 +33,6 @@ import urllib2
 import httplib
 import re
 from socket import error as SocketError
-from datetime import datetime
 
 class Eutils:
 
@@ -174,23 +173,18 @@ class Eutils:
                 else:
                     serverTransaction = True
             except urllib2.HTTPError as e:
-                print "urllib2.HTTPError at ", datetime.now()
                 serverTransaction = False
                 self.logger.info("urlopen error:%s, %s" % (e.code, e.read() ) )
             except httplib.IncompleteRead as e:
-                print "httplib.IncompleteRead at ", datetime.now()
                 serverTransaction = False
                 self.logger.info("IncompleteRead error")
             except urllib2.URLError as e:
-                print "urllib2.URLError at ", datetime.now()
                 serverTransaction = False
                 self.logger.info("No route to host: %s" % ( e.errno ) )
             except SocketError as e:
-                print "SocketError at ", datetime.now()
                 self.logger.info("Connection reset by peer: %s\n Try to reconnect" % (e.errno))
 		break
             except httplib.BadStatusLine as e:
-		print "httplib.BadStatusLine at ", datetime.now()
                 serverTransaction = False
                 self.logger.info("Bad status line: %s" % e.line)
         fasta = self.sanitiser(self.dbname, fasta) #

--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
@@ -33,6 +33,7 @@ import urllib2
 import httplib
 import re
 from socket import error as SocketError
+from datetime import datetime
 
 class Eutils:
 
@@ -173,26 +174,27 @@ class Eutils:
                 else:
                     serverTransaction = True
             except urllib2.HTTPError as e:
+                print "urllib2.HTTPError at ", datetime.now()
                 serverTransaction = False
                 self.logger.info("urlopen error:%s, %s" % (e.code, e.read() ) )
             except httplib.IncompleteRead as e:
+                print "httplib.IncompleteRead at ", datetime.now()
                 serverTransaction = False
-                self.logger.info("IncompleteRead error:  %s" % ( e.partial ) )
+                self.logger.info("IncompleteRead error")
             except urllib2.URLError as e:
-                print "EXCEPT"
+                print "urllib2.URLError at ", datetime.now()
                 serverTransaction = False
                 self.logger.info("No route to host: %s" % ( e.errno ) )
             except SocketError as e:
-                if e.errno != errno.ECONNRESET:
-                    print "OUPS"
-                    serverTransaction = False
-                    self.logger.info("Connection error: %s" % (e.errno))
-                    raise  # Not error we are looking for
-                print "UH OH"
+                print "SocketError at ", datetime.now()
                 serverTransaction = False
                 self.logger.info("Connection reset by peer: %s\n Try to reconnect" % (e.errno))
                 data = urllib.urlencode(values)
                 req = urllib2.Request(url, data)
+            except httplib.BadStatusLine as e:
+                print "httplib.BadStatusLine at ", datetime.now()
+                serverTransaction = False
+                self.logger.info("Bad status line: %s" % e.line)
         fasta = self.sanitiser(self.dbname, fasta) #
         time.sleep(1)
         return fasta

--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
@@ -32,6 +32,8 @@ import urllib
 import urllib2
 import httplib
 import re
+from socket import error as SocketError
+
 class Eutils:
 
     def __init__(self, options, logger):
@@ -176,6 +178,21 @@ class Eutils:
             except httplib.IncompleteRead as e:
                 serverTransaction = False
                 self.logger.info("IncompleteRead error:  %s" % ( e.partial ) )
+            except urllib2.URLError as e:
+                print "EXCEPT"
+                serverTransaction = False
+                self.logger.info("No route to host: %s" % ( e.errno ) )
+            except SocketError as e:
+                if e.errno != errno.ECONNRESET:
+                    print "OUPS"
+                    serverTransaction = False
+                    self.logger.info("Connection error: %s" % (e.errno))
+                    raise  # Not error we are looking for
+                print "UH OH"
+                serverTransaction = False
+                self.logger.info("Connection reset by peer: %s\n Try to reconnect" % (e.errno))
+                data = urllib.urlencode(values)
+                req = urllib2.Request(url, data)
         fasta = self.sanitiser(self.dbname, fasta) #
         time.sleep(1)
         return fasta

--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
@@ -187,14 +187,15 @@ class Eutils:
                 self.logger.info("No route to host: %s" % ( e.errno ) )
             except SocketError as e:
                 print "SocketError at ", datetime.now()
-                serverTransaction = False
                 self.logger.info("Connection reset by peer: %s\n Try to reconnect" % (e.errno))
-                data = urllib.urlencode(values)
-                req = urllib2.Request(url, data)
+		break
             except httplib.BadStatusLine as e:
-                print "httplib.BadStatusLine at ", datetime.now()
+		print "httplib.BadStatusLine at ", datetime.now()
                 serverTransaction = False
                 self.logger.info("Bad status line: %s" % e.line)
+            if counter>=100:
+                self.logger.info("Connection problem. Exiting")
+		break
         fasta = self.sanitiser(self.dbname, fasta) #
         time.sleep(1)
         return fasta

--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
@@ -193,9 +193,6 @@ class Eutils:
 		print "httplib.BadStatusLine at ", datetime.now()
                 serverTransaction = False
                 self.logger.info("Bad status line: %s" % e.line)
-            if counter>=100:
-                self.logger.info("Connection problem. Exiting")
-		break
         fasta = self.sanitiser(self.dbname, fasta) #
         time.sleep(1)
         return fasta

--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
@@ -165,28 +165,16 @@ class Eutils:
         while not serverTransaction:
             counter += 1
             self.logger.info("Server Transaction Trial:  %s" % ( counter ) )
-            try:
-                response = urllib2.urlopen(req)
-                fasta = response.read()
-                if ("Resource temporarily unavailable" in fasta) or ("Error" in fasta) or (not fasta.startswith(">") ):
+            response = urllib2.urlopen(req)
+	    print response.getcode()
+            if response.getcode() == 200:
+	        fasta = response.read()
+		if ("Resource temporarily unavailable" in fasta) or ("Error" in fasta) or (not fasta.startswith(">") ):
                     serverTransaction = False
+		    print "fasta error"
                 else:
                     serverTransaction = True
-            except urllib2.HTTPError as e:
-                serverTransaction = False
-                self.logger.info("urlopen error:%s, %s" % (e.code, e.read() ) )
-            except httplib.IncompleteRead as e:
-                serverTransaction = False
-                self.logger.info("IncompleteRead error")
-            except urllib2.URLError as e:
-                serverTransaction = False
-                self.logger.info("No route to host: %s" % ( e.errno ) )
-            except SocketError as e:
-                self.logger.info("Connection reset by peer: %s\n Try to reconnect" % (e.errno))
-		break
-            except httplib.BadStatusLine as e:
-                serverTransaction = False
-                self.logger.info("Bad status line: %s" % e.line)
+		    print "severTransaction = True"
         fasta = self.sanitiser(self.dbname, fasta) #
         time.sleep(1)
         return fasta


### PR DESCRIPTION
I catch exceptions to every error I have found while testing. 
Sometimes no error is thrown but instead of sequences we retrieve error messages. In this case, we also try to retrieve the same batch again. 
I only got the connection reset by peer once, so I just break it, as I couldn't test how to fix it.
