### PR TITLE
Update required bowtie package to reach parity with conda

### DIFF
--- a/tools/msp_sr_bowtie/sRbowtie.xml
+++ b/tools/msp_sr_bowtie/sRbowtie.xml
@@ -1,7 +1,7 @@
-<tool id="bowtieForSmallRNA" name="sRbowtie" version="1.1.2">
+<tool id="bowtieForSmallRNA" name="sRbowtie" version="1.1.2.1">
     <description>for FASTA small reads</description>
     <requirements>
-        <requirement type="package" version="0.12.7">bowtie</requirement>
+        <requirement type="package" version="1.1.2">bowtie</requirement>
         <requirement type="package" version="1.2">samtools</requirement>
     </requirements>
     <command interpreter="python"> sRbowtie.py --input $input

--- a/tools/msp_sr_bowtie/tool_dependencies.xml
+++ b/tools/msp_sr_bowtie/tool_dependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="bowtie" version="0.12.7">
-         <repository name="package_bowtie_0_12_7" owner="devteam" prior_installation_required="False" />
+    <package name="bowtie" version="1.1.2">
+         <repository name="package_bowtie_1_1_2" owner="iuc" prior_installation_required="False" />
     </package>
     <package name="samtools" version="1.2">
          <repository name="package_samtools_1_2" owner="iuc" prior_installation_required="False" />


### PR DESCRIPTION
planemo test still gives same test-result, and changes were minimal between 0.12.7 and 1.x.