### PR TITLE
add R dependency in xml tool form

### DIFF
--- a/tools/msp_sr_readmap_and_size_histograms/readmap.xml
+++ b/tools/msp_sr_readmap_and_size_histograms/readmap.xml
@@ -4,6 +4,7 @@
         <requirement type="package" version="1.0.0">bowtie</requirement>
         <requirement type="package" version="0.9.0">pysam</requirement>
         <requirement type="package" version="1.9.3">numpy</requirement>
+        <requirement type="package" version="3.1.2">R</requirement>
         <requirement type="package" version="1.3.0=r3.2.2_1">r-optparse</requirement>
         <requirement type="package" version="0.6_26=r3.2.2_2a">r-latticeextra</requirement>
         <requirement type="package" version="2.0.0=r3.2.2_0a">r-gridextra</requirement>


### PR DESCRIPTION
I don't see why this issue escaped to the tests, but it seems definitely required for planemo serve `-conda_dependency_resolution`

On a side note, the current test process is still not working smoothly