### PR TITLE
Lumpy pythonenv

### DIFF
--- a/tools/lumpy/lumpy.xml
+++ b/tools/lumpy/lumpy.xml
@@ -3,7 +3,7 @@
     <requirements>
         <requirement type="package" version="0.2.12">lumpy-sv</requirement>
         <requirement type="package" version="1.3.1">samtools</requirement>
-        <requirement type="package" version="1.11.2">numpy</requirement>
+        <requirement type="package" version="1.11.2=py27_0">numpy</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" level="fatal" description="Tool exception" />

--- a/tools/lumpy/lumpy.xml
+++ b/tools/lumpy/lumpy.xml
@@ -1,4 +1,4 @@
-<tool id="lumpy" name="lumpy-sv" version="0.3.0">
+<tool id="lumpy" name="lumpy-sv" version="0.3.1">
     <description>find structural variants</description>
     <requirements>
         <requirement type="package" version="0.2.12">lumpy-sv</requirement>


### PR DESCRIPTION
forcing numpy to python 2.7 version to avoid unpredictable success of lumpy installation (which depended on previous tool installations)