### PR TITLE
Repenrich and edger-repenrich bumped to 1.0.0

### DIFF
--- a/tools/repenrich/edger-repenrich.xml
+++ b/tools/repenrich/edger-repenrich.xml
@@ -1,4 +1,4 @@
-<tool id="edger-repenrich" name="edgeR-repenrich" version="0.3.0">
+<tool id="edger-repenrich" name="edgeR-repenrich" version="1.0.0">
     <description>Determines differentially expressed features from RepEnrich counts</description>
     <requirements>
         <requirement type="package" version="3.16.5">bioconductor-edger</requirement>

--- a/tools/repenrich/edger-repenrich.xml
+++ b/tools/repenrich/edger-repenrich.xml
@@ -1,10 +1,10 @@
 <tool id="edger-repenrich" name="edgeR-repenrich" version="0.3.0">
     <description>Determines differentially expressed features from RepEnrich counts</description>
     <requirements>
-        <requirement type="package" version="3.16.5-r3.3.1_0">bioconductor-edger</requirement>
-        <requirement type="package" version="3.30.13-r3.3.1_0">bioconductor-limma</requirement>
-        <requirement type="package" version="1.20.0-r3.3.1_0">r-getopt</requirement>
-        <requirement type="package" version="0.2.15-r3.3.1_0">r-rjson</requirement>
+        <requirement type="package" version="3.16.5">bioconductor-edger</requirement>
+        <requirement type="package" version="3.30.13">bioconductor-limma</requirement>
+        <requirement type="package" version="1.20.0">r-getopt</requirement>
+        <requirement type="package" version="0.2.15">r-rjson</requirement>
     </requirements>
     <stdio>
         <regex match="Execution halted"

--- a/tools/repenrich/repenrich.xml
+++ b/tools/repenrich/repenrich.xml
@@ -1,4 +1,4 @@
-<tool id="repenrich" name="RepEnrich" version="0.3.0">
+<tool id="repenrich" name="RepEnrich" version="1.0.0">
     <description>Repeat Element Profiling</description>
     <requirements>
         <requirement type="package" version="1.2.0">bowtie</requirement>


### PR DESCRIPTION
removing the r-version suffixes in depencies of edger-repenrich does not hurt anymore, now that the appropriate conda package versions are determined