### PR TITLE
Cleaning retrieve fasta from ncbi

### DIFF
--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
@@ -227,7 +227,7 @@ class Eutils:
             if (counter > 500):
                 serverTransaction = True
         if (counter > 500):
-            raise QueryException({"message":"500 Server Transaction Trials attempted for this batch. Guiving up."})
+            raise QueryException({"message":"500 Server Transaction Trials attempted for this batch. Aborting."})
         fasta = self.sanitiser(self.dbname, fasta) 
         time.sleep(0.1)
         return fasta

--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
@@ -32,6 +32,10 @@ import httplib
 import re
 
 
+class QueryException(Exception):
+    pass
+
+
 class Eutils:
 
     def __init__(self, options, logger):
@@ -62,9 +66,14 @@ class Eutils:
         # If no UIDs are found exit script
         if self.count > 0:
             self.get_uids_list()
-            self.get_sequences()
+            try:
+                self.get_sequences()
+            except QueryException as e:
+                self.logger.error("Exiting script.")
+                raise e
         else:
-            self.logger.info("No UIDs were found. Exiting script.")
+            self.logger.error("No UIDs were found. Exiting script.")
+            raise Exception("")
 
     def get_count_value(self):
         """
@@ -218,7 +227,7 @@ class Eutils:
             if (counter > 500):
                 serverTransaction = True
         if (counter > 500):
-            return "counter"
+            raise QueryException({"message":"500 Server Transaction Trials attempted for this batch. Guiving up."})
         fasta = self.sanitiser(self.dbname, fasta) 
         time.sleep(0.1)
         return fasta
@@ -282,11 +291,12 @@ class Eutils:
                     mfasta = ''
                     while not mfasta:
                         self.logger.info("retrieving batch %d" % ((start / batch_size) + 1))
-                        mfasta = self.efetch(self.dbname, self.query_key, self.webenv)
-                    if ("counter" not in mfasta):
-                        out.write(mfasta + '\n')
-                    else:
-                        self.logger.info("Server Trials numbered more than 500. Skipping this batch")
+                        try:
+                            mfasta = self.efetch(self.dbname, self.query_key, self.webenv)
+                            out.write(mfasta + '\n')
+                        except QueryException as e:
+                            self.logger.error("%s" % e.message)
+                            raise e
 
 
 LOG_FORMAT = '%(asctime)s|%(levelname)-8s|%(message)s'
@@ -316,7 +326,10 @@ def __main__():
     logger = logging.getLogger('data_from_NCBI')
     
     E = Eutils(options, logger)
-    E.retrieve()
+    try:
+        E.retrieve()
+    except Exception as e:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.xml
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.xml
@@ -1,4 +1,4 @@
-<tool id="retrieve_fasta_from_NCBI" name="Retrieve FASTA from NCBI" version="1.0.0">
+<tool id="retrieve_fasta_from_NCBI" name="Retrieve FASTA from NCBI" version="1.1.0">
   <description></description>
   <command><![CDATA[
       python '$__tool_directory__'/retrieve_fasta_from_NCBI.py


### PR DESCRIPTION
Bumped script to 1.1 and added a way to handle Error in fasta so the script doesn't loop infinitely