### PR TITLE
add dependency gnu-wget to mircounts to get rid off wget mis-use

### DIFF
--- a/tools/mircounts/mircounts.xml
+++ b/tools/mircounts/mircounts.xml
@@ -1,6 +1,7 @@
-<tool id="mircounts" name="miRcounts" version="0.9.1">
+<tool id="mircounts" name="miRcounts" version="0.9.2">
     <description> Counts miRNA alignments from small RNA sequence data</description>
     <requirements>
+        <requirement type="package" version="1.18">gnu-wget</requirement>
         <requirement type="package" version="1.2">bowtie</requirement>
         <requirement type="package" version="1.4.1">samtools</requirement>
         <requirement type="package" version="0.11.2.1">pysam</requirement>


### PR DESCRIPTION
Strangely, the tool cannot find the /usr/bin/wget program in mississippi although this one is there, accessible in conda env, etc... Even hard specification in the xml: `/usr/bin/wget` doesn not fix the bug. Yet, everything works on plastisipi or fresh galaxy instances...

Anyway, to get rid off this bug, we can add gnu-wget conda package as a dependency in the tool !