### PR TITLE
Removed 'edat' from retrieve because it is only available for pubmed

### DIFF
--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.py
@@ -356,10 +356,10 @@ def __main__():
     parser.add_option('-d', dest='dbname', help='database type')
     parser.add_option('-l', '--logfile', help='log file (default=stderr)')
     parser.add_option('--datetype', dest='datetype',
-                      choices=['mdat', 'edat', 'pdat'],
+                      choices=['mdat', 'pdat'],
                       help='Type of date used to limit a search.\
-                            [ mdat(modification date), pdat(publication date),\
-                            edat(entrez date)] (default=pdat)', default='pdat')
+                            [ mdat(modification date), pdat(publication date)]\
+                            (default=pdat)', default='pdat')
     parser.add_option('--reldate', dest='reldate',
                       help='When reldate is set to an integer n, the search\
                             returns only those items that have a date\

--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.xml
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.xml
@@ -35,7 +35,6 @@
         <when value="YES">
             <param name="datetype" type="select">
                 <option value="pdat">Publication date</option>
-                <option value="edat">Entrez date</option>
                 <option value="mdat">Modification date</option>
             </param>
             <param name="mindate" type="text" help="Date must follow one of the following formats: YYYY/MM/DD, YYYY/MM or YYYY"/>

--- a/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.xml
+++ b/tools/fetch_fasta_from_ncbi/retrieve_fasta_from_NCBI.xml
@@ -1,4 +1,4 @@
-<tool id="retrieve_fasta_from_NCBI" name="Retrieve FASTA from NCBI" version="2.0.0">
+<tool id="retrieve_fasta_from_NCBI" name="Retrieve FASTA from NCBI" version="2.0.1">
   <description></description>
   <command><![CDATA[
       python '$__tool_directory__'/retrieve_fasta_from_NCBI.py


### PR DESCRIPTION
Since we only use the nuccore and prot databases 'edat' is useless in this case