### PR TITLE
Check parsing

### DIFF
--- a/tools/blast_unmatched/blast_unmatched.py
+++ b/tools/blast_unmatched/blast_unmatched.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import optparse
-
+import re
 
 def parse_options():
     """
@@ -36,10 +36,13 @@ def get_unmatched(output_file, fasta_file, matched):
     """
     output_file_handle = open(output_file, 'w')
     unmatched = False
+    end = re.compile(".+\W$")
     with open(fasta_file, 'r') as infile:
         for line in infile:
             if line.startswith('>'):
                 subline = line[1:100].rstrip() #qid are 100chars long in blast
+                while end.match(subline) != None:
+                    subline = subline[:-1]
                 if subline not in matched:
                     output_file_handle.write(line)
                     unmatched = True

--- a/tools/blast_unmatched/blast_unmatched.py
+++ b/tools/blast_unmatched/blast_unmatched.py
@@ -40,7 +40,7 @@ def get_unmatched(output_file, fasta_file, matched):
     with open(fasta_file, 'r') as infile:
         for line in infile:
             if line.startswith('>'):
-                subline = line[1:100].rstrip() #qid are 100chars long in blast
+                subline = line[1:].rstrip() #qid are 100chars long in blast
                 while end.match(subline) != None:
                     subline = subline[:-1]
                 if subline not in matched:

--- a/tools/blast_unmatched/blast_unmatched.xml
+++ b/tools/blast_unmatched/blast_unmatched.xml
@@ -1,4 +1,4 @@
-<tool id="blast_unmatched" name="Blast Unmatched" version="0.2.0">
+<tool id="blast_unmatched" name="Blast Unmatched" version="0.3.0">
     <description>get query sequences that didn't get a match during a blast</description>
     <requirements>
     </requirements>

--- a/tools/blast_unmatched/blast_unmatched.xml
+++ b/tools/blast_unmatched/blast_unmatched.xml
@@ -1,4 +1,4 @@
-<tool id="blast_unmatched" name="Blast Unmatched" version="0.3.0">
+<tool id="blast_unmatched" name="Blast Unmatched" version="0.4.0">
     <description>get query sequences that didn't get a match during a blast</description>
     <requirements>
     </requirements>


### PR DESCRIPTION
Modified parsing since blast removes the non-alphabetical or numerical characters at the end of the headers.