### PR TITLE
improve treatment of sam imputs

### DIFF
--- a/tools/rsem/macros.xml
+++ b/tools/rsem/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
   <macros>
-    <token name="@WRAPPER_VERSION@">0.5.2</token>
+    <token name="@WRAPPER_VERSION@">0.5.3</token>
     <xml name="rsem_options">
         <param name="seedlength" type="integer" value="25" optional="true" label="Seed length used by the read aligner" help="Providing the correct value for this parameter is important for RSEM's accuracy if the data are single-end reads. RSEM uses this value for Bowtie's seed length parameter. The minimum value is 25. (Default:25)">
         </param>

--- a/tools/rsem/macros.xml
+++ b/tools/rsem/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
   <macros>
-    <token name="@WRAPPER_VERSION@">0.5.1</token>
+    <token name="@WRAPPER_VERSION@">0.5.2</token>
     <xml name="rsem_options">
         <param name="seedlength" type="integer" value="25" optional="true" label="Seed length used by the read aligner" help="Providing the correct value for this parameter is important for RSEM's accuracy if the data are single-end reads. RSEM uses this value for Bowtie's seed length parameter. The minimum value is 25. (Default:25)">
         </param>

--- a/tools/rsem/rsem-bwt2.xml
+++ b/tools/rsem/rsem-bwt2.xml
@@ -46,15 +46,15 @@
       &&
     #end if
     
-    #if $run_rsem.select == "Yes":
+    #if $run_rsem.select == "Yes" and $run_rsem.input.format == 'fastq':
       ## uncompress fastq.gz or fastqsanger.gz if needed
-      #if $run_rsem.input.fastq.matepair=="single":
+      #if $run_rsem.input.format == 'fastq' and $run_rsem.input.fastq.matepair=="single":
         #if $run_rsem.input.fastq.singlefastq.is_of_type('fastq.gz') or $run_rsem.input.fastq.singlefastq.is_of_type('fastqsanger.gz'):
           gunzip < '$run_rsem.input.fastq.singlefastq' > uncomp_single.fastq &&
         #elif $run_rsem.input.fastq.singlefastq.is_of_type('fastq') or $run_rsem.input.fastq.singlefastq.is_of_type('fastqsanger'):
           ln -f -s '$run_rsem.input.fastq.singlefastq' 'uncomp_single.fastq' &&
         #end if
-      #elif $run_rsem.input.fastq.matepair=="paired":
+      #elif $run_rsem.input.format == 'fastq' and $run_rsem.input.fastq.matepair=="paired":
         #if $run_rsem.input.fastq.fastq1.is_of_type('fastq.gz') or $run_rsem.input.fastq.fastq1.is_of_type('fastqsanger.gz'):
           gunzip < '$run_rsem.input.fastq.fastq1' > uncomp_pair1.fastq &&
           gunzip < '$run_rsem.input.fastq.fastq2' > uncomp_pair2.fastq &&
@@ -145,9 +145,9 @@
         #if $run_rsem.input.matepair=="paired":
           --paired-end
         #end if
-        #if $run_rsem.input.rsem_sam._extension == 'sam':
+        #if $run_rsem.input.rsem_sam.is_of_type('sam'):
           --sam
-        #elif $run_rsem.input.rsem_sam._extension == 'bam':
+        #elif $run_rsem.input.rsem_sam.is_of_type('bam'):
           --bam
         #end if
         $run_rsem.input.rsem_sam

--- a/tools/rsem/rsem-bwt2.xml
+++ b/tools/rsem/rsem-bwt2.xml
@@ -295,7 +295,7 @@
                 <option value="single">Single End Reads</option>
                 <option value="paired">Paired End Reads</option>
               </param>
-              <param name="rsem_sam" type="data" format="rsem_sam" label="RSEM formatted SAM file" />
+              <param name="rsem_sam" type="data" format="sam,bam" label="RSEM formatted SAM file" />
           </when>
         </conditional>
         <expand macro="rsem_options"/>

--- a/tools/rsem/rsem.xml
+++ b/tools/rsem/rsem.xml
@@ -48,13 +48,13 @@
     
     #if $run_rsem.select == "Yes":
       ## uncompress fastq.gz or fastqsanger.gz if needed
-      #if $run_rsem.input.fastq.matepair=="single":
+      #if $run_rsem.input.format == 'fastq' and $run_rsem.input.fastq.matepair=="single":
         #if $run_rsem.input.fastq.singlefastq.is_of_type('fastq.gz') or $run_rsem.input.fastq.singlefastq.is_of_type('fastqsanger.gz'):
           gunzip < '$run_rsem.input.fastq.singlefastq' > uncomp_single.fastq &&
         #elif $run_rsem.input.fastq.singlefastq.is_of_type('fastq') or $run_rsem.input.fastq.singlefastq.is_of_type('fastqsanger'):
           ln -f -s '$run_rsem.input.fastq.singlefastq' 'uncomp_single.fastq' &&
         #end if
-      #elif $run_rsem.input.fastq.matepair=="paired":
+      #elif $run_rsem.input.format == 'fastq' and $run_rsem.input.fastq.matepair=="paired":
         #if $run_rsem.input.fastq.fastq1.is_of_type('fastq.gz') or $run_rsem.input.fastq.fastq1.is_of_type('fastqsanger.gz'):
           gunzip < '$run_rsem.input.fastq.fastq1' > uncomp_pair1.fastq &&
           gunzip < '$run_rsem.input.fastq.fastq2' > uncomp_pair2.fastq &&
@@ -152,9 +152,9 @@
         #if $run_rsem.input.matepair=="paired":
           --paired-end
         #end if
-        #if $run_rsem.input.rsem_sam._extension == 'sam':
+        #if $run_rsem.input.rsem_sam.is_of_type('sam'):
           --sam
-        #elif $run_rsem.input.rsem_sam._extension == 'bam':
+        #elif $run_rsem.input.rsem_sam.is_of_type('bam'):
           --bam
         #end if
         $run_rsem.input.rsem_sam

--- a/tools/rsem/rsem.xml
+++ b/tools/rsem/rsem.xml
@@ -302,7 +302,7 @@
                 <option value="single">Single End Reads</option>
                 <option value="paired">Paired End Reads</option>
               </param>
-              <param name="rsem_sam" type="data" format="rsem_sam" label="RSEM formatted SAM file" />
+              <param name="rsem_sam" type="data" format="sam,bam" label="RSEM formatted SAM file" />
           </when>
         </conditional>
         <expand macro="rsem_options"/>


### PR DESCRIPTION
This is not optimal yet: the bam must be generated with the .idx.fa file of the rsem reference and the alternate aligner; plus, a conversion with a rsem script. Not sure that working on sam input preparation is very useful.