### PR TITLE
Remove --no-polyA which is not a valid argument for rsem-1.3.0

### DIFF
--- a/tools/rsem/macros.xml
+++ b/tools/rsem/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
   <macros>
-    <token name="@WRAPPER_VERSION@">0.8.0</token>
+    <token name="@WRAPPER_VERSION@">0.9.0</token>
     <xml name="rsem_options">
         <param name="seedlength" type="integer" value="25" optional="true" label="Seed length used by the read aligner" help="Providing the correct value for this parameter is important for RSEM's accuracy if the data are single-end reads. RSEM uses this value for Bowtie's seed length parameter. The minimum value is 25. (Default:25)">
         </param>

--- a/tools/rsem/rsem-bwt2.xml
+++ b/tools/rsem/rsem-bwt2.xml
@@ -24,8 +24,6 @@
         #if $job.polya.polya_length:
           --polyA-length $job.polya.polya_length
         #end if
-      #elif $job.polya.polya_use == 'none':
-        --no-polyA
       #end if
       $job.ntog
       #if $job.transcript_to_gene_map:

--- a/tools/rsem/rsem.xml
+++ b/tools/rsem/rsem.xml
@@ -24,8 +24,6 @@
         #if $job.polya.polya_length:
           --polyA-length $job.polya.polya_length
         #end if
-      #elif $job.polya.polya_use == 'none':
-        --no-polyA
       #end if
       $job.ntog
       #if $job.transcript_to_gene_map:


### PR DESCRIPTION
This removes --no-polyA, which causes a rsem-prepare-reference error at tool runtime when the corresponding interface option is selected.