### PR TITLE
put hash comment character in tabular outputs

### DIFF
--- a/tools/small_rna_maps/small_rna_maps.py
+++ b/tools/small_rna_maps/small_rna_maps.py
@@ -374,14 +374,14 @@ def main(inputs, samples, methods, outputs, minsize, maxsize, cluster,
     for method, output in zip(methods, outputs):
         out = open(output, 'w')
         if method == 'Size':
-            header = ["Dataset", "Chromosome", "Polarity", method, "Counts",
+            header = ["# Dataset", "Chromosome", "Polarity", method, "Counts",
                       "Strandness", "z-score"]
         elif cluster:
-            header = ["Dataset", "Chromosome", "Chrom_length", "Coordinate",
+            header = ["# Dataset", "Chromosome", "Chrom_length", "Coordinate",
                       "Polarity", method, "Start-End", "Cluster Size",
                       "density"]
         else:
-            header = ["Dataset", "Chromosome", "Chrom_length", "Coordinate",
+            header = ["# Dataset", "Chromosome", "Chrom_length", "Coordinate",
                       "Polarity", method]
         out.write('\t'.join(header) + '\n')
         for input, sample in zip(inputs, samples):

--- a/tools/small_rna_maps/small_rna_maps.r
+++ b/tools/small_rna_maps/small_rna_maps.r
@@ -28,6 +28,7 @@ args = parse_args(parser)
 # data frames implementation
 ## first table
 Table = read.delim(args$first_dataframe, header=T, row.names=NULL)
+colnames(Table)[1] <- "Dataset"
 if (args$first_plot_method == "Counts" | args$first_plot_method == "Size") {
   Table <- within(Table, Counts[Polarity=="R"] <- (Counts[Polarity=="R"]*-1))
 }
@@ -52,6 +53,7 @@ n_genes=length(per_gene_readmap)
 # second table
 if (args$extra_plot_method != '') {
   ExtraTable=read.delim(args$extra_dataframe, header=T, row.names=NULL)
+  colnames(ExtraTable)[1] <- "Dataset"
   if (args$extra_plot_method == "Counts" | args$extra_plot_method=='Size') {
     ExtraTable <- within(ExtraTable, Counts[Polarity=="R"] <- (Counts[Polarity=="R"]*-1))
   }

--- a/tools/small_rna_maps/small_rna_maps.xml
+++ b/tools/small_rna_maps/small_rna_maps.xml
@@ -1,4 +1,4 @@
-<tool id="small_rna_maps" name="small_rna_maps" version="2.13.1">
+<tool id="small_rna_maps" name="small_rna_maps" version="2.13.2">
   <description></description>
   <requirements>
         <requirement type="package" version="1.11.2=py27_0">numpy</requirement>

--- a/tools/small_rna_maps/test-data/clustering.tab
+++ b/tools/small_rna_maps/test-data/clustering.tab
@@ -1,4 +1,4 @@
-Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Counts	Start-End	Cluster Size	density
+# Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Counts	Start-End	Cluster Size	density
 input1.bam	FBtr0070001	72	1	F	0	1-1	1	0.0
 input1.bam	FBtr0070001	72	12	F	12	7-39	33	0.363636363636
 input1.bam	FBtr0070001	72	30	F	42	27-53	27	1.55555555556

--- a/tools/small_rna_maps/test-data/clustering_unstranded.tab
+++ b/tools/small_rna_maps/test-data/clustering_unstranded.tab
@@ -1,4 +1,4 @@
-Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Counts	Start-End	Cluster Size	density
+# Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Counts	Start-End	Cluster Size	density
 input1.bam	FBtr0070001	72	1	F	0	1-1	1	0.0
 input1.bam	FBtr0070001	72	12	F	12	7-39	33	0.363636363636
 input1.bam	FBtr0070001	72	30	F	42	27-53	27	1.55555555556

--- a/tools/small_rna_maps/test-data/input1_counts_yminneg5_5.tab
+++ b/tools/small_rna_maps/test-data/input1_counts_yminneg5_5.tab
@@ -1,4 +1,4 @@
-Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Counts
+# Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Counts
 input1.bam	FBtr0070001	72	1	F	0
 input1.bam	FBtr0070001	72	7	F	5
 input1.bam	FBtr0070001	72	8	F	3

--- a/tools/small_rna_maps/test-data/input1_input2_counts.tab
+++ b/tools/small_rna_maps/test-data/input1_input2_counts.tab
@@ -1,4 +1,4 @@
-Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Counts
+# Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Counts
 input1.bam	FBtr0070001	72	1	F	0
 input1.bam	FBtr0070001	72	7	F	5
 input1.bam	FBtr0070001	72	8	F	3

--- a/tools/small_rna_maps/test-data/input1_input2_norm_1_2_counts.tab
+++ b/tools/small_rna_maps/test-data/input1_input2_norm_1_2_counts.tab
@@ -1,4 +1,4 @@
-Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Counts
+# Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Counts
 input1.bam	FBtr0070001	72	1	F	0
 input1.bam	FBtr0070001	72	7	F	5
 input1.bam	FBtr0070001	72	8	F	3

--- a/tools/small_rna_maps/test-data/input1_input2_size.tab
+++ b/tools/small_rna_maps/test-data/input1_input2_size.tab
@@ -1,4 +1,4 @@
-Dataset	Chromosome	Polarity	Size	Counts	Strandness	z-score
+# Dataset	Chromosome	Polarity	Size	Counts	Strandness	z-score
 input1.bam	FBtr0070001	F	19	1	1.0	-0.448696330732
 input1.bam	FBtr0070001	F	20	4	1.0	-0.104347983891
 input1.bam	FBtr0070001	F	21	4	1.0	-0.104347983891

--- a/tools/small_rna_maps/test-data/input1_input2new_norm_1_2_counts.tab
+++ b/tools/small_rna_maps/test-data/input1_input2new_norm_1_2_counts.tab
@@ -1,4 +1,4 @@
-Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Counts
+# Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Counts
 input1.bam	FBtr0070001	72	1	F	0
 input1.bam	FBtr0070001	72	7	F	5
 input1.bam	FBtr0070001	72	8	F	3

--- a/tools/small_rna_maps/test-data/input1_mean.tab
+++ b/tools/small_rna_maps/test-data/input1_mean.tab
@@ -1,4 +1,4 @@
-Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Mean
+# Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Mean
 input1.bam	FBtr0070001	72	1	F	0
 input1.bam	FBtr0070001	72	7	F	21.2
 input1.bam	FBtr0070001	72	8	F	21.3

--- a/tools/small_rna_maps/test-data/input1_median.tab
+++ b/tools/small_rna_maps/test-data/input1_median.tab
@@ -1,4 +1,4 @@
-Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Median
+# Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Median
 input1.bam	FBtr0070001	72	1	F	0
 input1.bam	FBtr0070001	72	7	F	21.0
 input1.bam	FBtr0070001	72	8	F	21.0

--- a/tools/small_rna_maps/test-data/input1_min20_max30_size.tab
+++ b/tools/small_rna_maps/test-data/input1_min20_max30_size.tab
@@ -1,4 +1,4 @@
-Dataset	Chromosome	Polarity	Size	Counts	Strandness	z-score
+# Dataset	Chromosome	Polarity	Size	Counts	Strandness	z-score
 input1.bam	FBtr0070001	F	19	1	1.0	-0.448696330732
 input1.bam	FBtr0070001	F	20	4	1.0	-0.104347983891
 input1.bam	FBtr0070001	F	21	4	1.0	-0.104347983891

--- a/tools/small_rna_maps/test-data/input_single_chr_x_6_single_plot_coverage.tab
+++ b/tools/small_rna_maps/test-data/input_single_chr_x_6_single_plot_coverage.tab
@@ -1,4 +1,4 @@
-Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Coverage
+# Dataset	Chromosome	Chrom_length	Coordinate	Polarity	Coverage
 input_single_chr.bam_0	1	80	1	F	0
 input_single_chr.bam_0	1	80	80	F	0
 input_single_chr.bam_1	1	80	1	F	0

--- a/tools/small_rna_maps/test-data/size.tab
+++ b/tools/small_rna_maps/test-data/size.tab
@@ -1,4 +1,4 @@
-Dataset	Chromosome	Polarity	Size	Counts	Strandness	z-score
+# Dataset	Chromosome	Polarity	Size	Counts	Strandness	z-score
 input1.bam	FBtr0070001	F	19	1	1.0	-0.448696330732
 input1.bam	FBtr0070001	F	20	4	1.0	-0.104347983891
 input1.bam	FBtr0070001	F	21	4	1.0	-0.104347983891


### PR DESCRIPTION
The hash character is balance by a colnames renaming on purpose in the R code
bump to version 2.13.2