### PR TITLE
Improve I/O of artbio_bam_cleaning

### DIFF
--- a/tools/artbio_bam_cleaning/artbio_bam_cleaning.xml
+++ b/tools/artbio_bam_cleaning/artbio_bam_cleaning.xml
@@ -1,4 +1,4 @@
-<tool id="artbio_bam_cleaning" name="ARTbio bam cleaning" version="1.7+galaxy1">
+<tool id="artbio_bam_cleaning" name="ARTbio bam cleaning" version="1.7+galaxy2">
     <description>
         on flags and PCR Duplicates and MD recalibration
     </description>
@@ -26,6 +26,8 @@
         > $calmd
     #else if $specify_outputs == 'calMDandMQ' or $specify_outputs == 'both':
         | tee $calmd
+        | sambamba view -h -t \${GALAXY_SLOTS:-2} --filter='mapping_quality <= 254' -f 'bam' /dev/stdin > $fullfilter
+    #else:
         | sambamba view -h -t \${GALAXY_SLOTS:-2} --filter='mapping_quality <= 254' -f 'bam' /dev/stdin > $fullfilter
     #end if
     ]]></command>


### PR DESCRIPTION
Removing the tee when only MQ output is required, to improve I/O performances