### PR TITLE
Remove print statements in overlaps.py

### DIFF
--- a/tools/small_rna_signatures/overlapping_reads.py
+++ b/tools/small_rna_signatures/overlapping_reads.py
@@ -90,12 +90,10 @@ class Map:
         target_range = self.target_range
         uppers = [seq for seq in uppers if (len(seq) in query_range or len(seq)
                   in target_range)]
-        print(uppers)
         uppers_expanded = []
         for seq in uppers:
             expand = [seq for i in range(self.readdic[seq])]
             uppers_expanded.extend(expand)
-        print(uppers_expanded)
         uppers = uppers_expanded
         lowers = [seq for seq in lowers if (len(seq) in query_range or len(seq)
                   in target_range)]
@@ -123,7 +121,6 @@ class Map:
         stringresult = []
         header_template = '>%s|coord=%s|strand %s|size=%s|nreads=%s\n%s\n'
         total_pairs = 0
-        print('Chromosome\tNbre of pairs')
         for chrom in sorted(self.chromosomes):
             number_pairs = 0
             for pos in self.all_query_positions[chrom]:
@@ -149,9 +146,6 @@ class Map:
                                      len(downread), self.readdic[downread],
                                      self.revcomp(downread)))
                 stringresult.extend(sorted(set(stringbuffer)))
-            print('%s\t%s' % (chrom, number_pairs))
-        print('Total nbre of pairs that can be simultaneously formed\t%s'
-              % total_pairs)
         F.write(''.join(stringresult))
 
     def revcomp(self, sequence):

--- a/tools/small_rna_signatures/overlapping_reads.xml
+++ b/tools/small_rna_signatures/overlapping_reads.xml
@@ -1,4 +1,4 @@
-<tool id="overlapping_reads" name="Get overlapping reads" version="3.4.1">
+<tool id="overlapping_reads" name="Get overlapping reads" version="3.4.2">
     <description />
     <requirements>
         <requirement type="package" version="0.18.0">pysam</requirement>

--- a/tools/small_rna_signatures/signature.xml
+++ b/tools/small_rna_signatures/signature.xml
@@ -1,4 +1,4 @@
-<tool id="signature" name="Small RNA Signatures" version="3.4.1>">
+<tool id="signature" name="Small RNA Signatures" version="3.4.2>">
     <description />
     <requirements>
         <requirement type="package" version="1.23.4">numpy</requirement>


### PR DESCRIPTION
which were there only for debbuging purposes