### PR TITLE
upgrade conda dependecies of wig_to_biwig

### DIFF
--- a/tools/bigwig_to_wig/.shed.yml
+++ b/tools/bigwig_to_wig/.shed.yml
@@ -6,7 +6,7 @@ long_description: |
   Converts a bigWig file to Wiggle (WIG) format
 categories:
   - Convert Formats
-homepage_url: http://artbio.fr
-remote_repository_url: https://github.com/ARTbio/tools-artbio/tree/master/tools/bigwig_to_wig
+homepage_url: https://artbio.fr
+remote_repository_url: https://github.com/ARTbio/tools-artbio/tree/main/tools/bigwig_to_wig
 toolshed:
   - toolshed

--- a/tools/bigwig_to_wig/bigwig_to_wig.sh
+++ b/tools/bigwig_to_wig/bigwig_to_wig.sh
@@ -54,22 +54,22 @@ echo "track type=wiggle_0 name=$mylab description=\"fixedStep format\""
 
 #for each chromsome
 while read line; do
- 
-  cur_chr=$(echo $line | cut --delimiter=" " -f1)
-  cur_length=$(echo $line | cut --delimiter=" " -f2)
-  
+
+  cur_chr=$(echo $line | cut -d " " -f1)
+  cur_length=$(echo $line | cut -d " " -f2)
+
   n_bins=$(echo "scale=0; (${cur_length}-${step_size})/${bin_size}" | bc)
- 
+
   start=1
   stop=$(echo "$n_bins * $bin_size" | bc)
 
   #write header line for each chromosome
   echo "fixedStep chrom=$cur_chr start=$start step=$step_size span=$step_size"
-  
+
   #get densities along chr in n_bins with chosen bin_size and step_size (giving overlap in bins)
   nice bigWigSummary $bigwig_file $cur_chr $start $stop $n_bins | perl -pe 's/\t/\n/g' | perl -pe "s/n\/a/0/" 
   #gives warning if no data in/for current chromosome
-  
+
 done < $org_assembly_file
 
 #rm tmp

--- a/tools/bigwig_to_wig/bigwig_to_wig.xml
+++ b/tools/bigwig_to_wig/bigwig_to_wig.xml
@@ -1,4 +1,4 @@
-<tool id="bigwig_to_wig" name="BigWig to Wig" version="2.0.0">
+<tool id="bigwig_to_wig" name="BigWig to Wig" version="@VERSION@">
     <description>converter</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/bigwig_to_wig/bigwig_to_wig.xml
+++ b/tools/bigwig_to_wig/bigwig_to_wig.xml
@@ -8,7 +8,7 @@
         <exit_code range="1:" level="fatal" description="Tool exception" />
     </stdio>
     <command detect_errors="exit_code"><![CDATA[
-        sh $__tool_directory__/bigwig_to_wig.sh -f $input -b $bin_size -l $mylab > $output
+        bash $__tool_directory__/bigwig_to_wig.sh -f $input -b $bin_size -l $mylab > $output
     ]]></command>
   <inputs>
       <param name="input" format="bigwig" type="data" label="BigWig file to convert" />

--- a/tools/bigwig_to_wig/bigwig_to_wig.xml
+++ b/tools/bigwig_to_wig/bigwig_to_wig.xml
@@ -23,13 +23,13 @@
 	      <param name="input" value="1.bigwig" />
 	      <param name="bin_size" value="500" />
 	      <param name="mylab" value="wiggle_file" />
-	      <output name="output" file="1.wig" />	  
+	      <output name="output" file="1.wig" compare="sim_size" />	  
       </test>
       <test>
 	      <param name="input" value="2.bigwig" />
 	      <param name="bin_size" value="2000" />
 	      <param name="mylab" value="wiggle_file" />
-	      <output name="output" file="2.wig" />	  
+	      <output name="output" file="2.wig" compare="sim_size" />	  
       </test>
     </tests>
     <help><![CDATA[

--- a/tools/bigwig_to_wig/macros.xml
+++ b/tools/bigwig_to_wig/macros.xml
@@ -2,9 +2,9 @@
     <token name="@VERSION@">2.0.0</token>
     <macro name="requirements">
     <requirements>
-        <requirement type="package" version="366">ucsc-bigwiginfo</requirement>
-        <requirement type="package" version="366">ucsc-bigwigsummary</requirement>
-        <requirement type="package" version="1.06">bc</requirement>
+        <requirement type="package" version="377">ucsc-bigwiginfo</requirement>
+        <requirement type="package" version="377">ucsc-bigwigsummary</requirement>
+        <requirement type="package" version="1.07.1">bc</requirement>
     </requirements>
     </macro>
 

--- a/tools/bigwig_to_wig/macros.xml
+++ b/tools/bigwig_to_wig/macros.xml
@@ -5,6 +5,7 @@
         <requirement type="package" version="377">ucsc-bigwiginfo</requirement>
         <requirement type="package" version="377">ucsc-bigwigsummary</requirement>
         <requirement type="package" version="1.07.1">bc</requirement>
+        <requirement type="package" version="5.32.1">perl</requirement>
     </requirements>
     </macro>
 

--- a/tools/bigwig_to_wig/macros.xml
+++ b/tools/bigwig_to_wig/macros.xml
@@ -33,15 +33,10 @@ The larger the bin size you choose, the lower resolution and the faster the conv
 
 **Credits**
 
-This tool is based on the script written by Jens Vilstrup Johansen and is an update of a Galaxy tool previously developed by nikos_.
-
-It uses bigWigInfo_ and bigWigSummary_.
-
-For support and bug reports contact Cedric Mendoza or Christophe Antoniewski or go to https://github.com/ARTbio/tools-artbio
+This tool is based on the script written by Jens Vilstrup Johansen and is an update
+of a Galaxy tool previously developed by nikos_.
 
 .. _nikos: https://toolshed.g2.bx.psu.edu/view/nikos/bigwig_to_wig/974af3268394
-.. _bigWigInfo: https://github.com/adamlabadorf/ucsc_tools/blob/master/executables/bigWigInfo
-.. _bigWigSummary: https://github.com/adamlabadorf/ucsc_tools/blob/master/executables/bigWigSummary
 
     </token>
 </macros>

--- a/tools/bigwig_to_wig/macros.xml
+++ b/tools/bigwig_to_wig/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@VERSION@">2.0.0</token>
+    <token name="@VERSION@">3+galaxy0</token>
     <macro name="requirements">
     <requirements>
         <requirement type="package" version="377">ucsc-bigwiginfo</requirement>


### PR DESCRIPTION
The purpose of this PR is mainly to test the new `main` default branch

In addition,
Upgrade dependencies in macro.xml
```
bc                        1.07.1               h7f98852_0    conda-forge
ucsc-bigwiginfo           377                  ha8a8165_3    bioconda
ucsc-bigwigsummary        377                  ha8a8165_3    bioconda
```