### PR TITLE
use read.delim instead of read.table in cpm_tpm_rpk tool

### DIFF
--- a/tools/cpm_tpm_rpk/cpm_tpm_rpk.R
+++ b/tools/cpm_tpm_rpk/cpm_tpm_rpk.R
@@ -161,7 +161,7 @@ tpm <- function(count, length) {
 
 #### running code ####
 
-data <- read.table(
+data <- read.delim(
   opt$data,
   check.names = FALSE,
   header = opt$colnames,
@@ -171,7 +171,7 @@ data <- read.table(
 
 if (opt$type == "tpm" || opt$type == "rpk") {
   gene_length <- as.data.frame(
-    read.table(
+    read.delim(
       opt$gene,
       header = opt$gene_header,
       row.names = 1,

--- a/tools/cpm_tpm_rpk/cpm_tpm_rpk.xml
+++ b/tools/cpm_tpm_rpk/cpm_tpm_rpk.xml
@@ -1,4 +1,4 @@
-<tool id="cpm_tpm_rpk" name="Generate CPM, TPM, RPK" version="0.5.0">
+<tool id="cpm_tpm_rpk" name="Generate CPM, TPM, RPK" version="0.5.1">
     <description>from raw counts expression values</description>
     <requirements>
         <requirement type="package" version="1.7.1">r-optparse</requirement>


### PR DESCRIPTION
[rstudio-export.zip](https://github.com/ARTbio/tools-artbio/files/12833835/rstudio-export.zip)

### Try this with the above input files

```
cpm <- function(count) {
  (count / colSums(count)) * 1000000
}


data <- read.delim( # same with read.table is FLAWED !
  "Galaxy-matrixCounts.tsv",
  check.names = FALSE,
  header = TRUE,
  row.names = 1,
  sep = "\t"
)

res <- cpm(data)
selected_genes <- read.table("JRH_genes_vector.txt", header = FALSE)
rownames(selected_genes) <- selected_genes$V1

sub_data <- merge(data, selected_genes, 
                  by = 'row.names',
                  all = FALSE)

sub_data <- data[rownames(data) %in% selected_genes$V1, ]
sub_res <- res[rownames(res) %in% selected_genes$V1, ] 
```
And pay attention to the number of rows in the "sub_" dataframes...