### PR TITLE
gyppy support ?

### DIFF
--- a/tools/guppy/.shed.yml
+++ b/tools/guppy/.shed.yml
@@ -5,7 +5,7 @@ long_description: |
 categories:
   - Nanopore
 homepage_url: http://artbio.fr
-remote_repository_url: https://github.com/ARTbio/tools-artbio/tree/master/tools/guppy
+remote_repository_url: https://github.com/ARTbio/tools-artbio/tree/main/tools/guppy
 toolshed:
   - testtoolshed
 #  - toolshed

--- a/tools/guppy/guppy_basecaller.xml
+++ b/tools/guppy/guppy_basecaller.xml
@@ -1,4 +1,4 @@
-<tool id="guppy-basecaller" name="Guppy basecaller wrapper" version="0.2.1" python_template_version="3.5">
+<tool id="guppy-basecaller" name="Guppy basecaller wrapper" version="0.2.2" python_template_version="3.8">
     <description>A simple wrapper for guppy basecaller that depends on configuration files</description>
     <requirements>
     </requirements>

--- a/tools/guppy/guppy_basecaller.xml
+++ b/tools/guppy/guppy_basecaller.xml
@@ -32,7 +32,7 @@
         and a configuration in the form of a tar file.
 
         You can find configurations at https://github.com/nanoporetech/rerio,
-        and in particular the directory https://github.com/nanoporetech/rerio/basecall_models.
+        and in particular the directory `nanoporetech/rerio/basecall_models`.
 
         Each file there contains a URL you can download to use, for example
         https://github.com/nanoporetech/rerio/blob/master/basecall_models/res_rna2_r941_min_flipflop_v001


### PR DESCRIPTION
At the occasion of refreshing guppy tool url, it seems that dorado from ONT is their next generation basecaller
Therefore I am not sure that the artbio wrapper will be supported in the future
@drosofff 