### PR TITLE
fix deprecated code in shed_tool_conf_xml_cleaner.py

### DIFF
--- a/scripts/helper_scripts/shed_tool_conf_xml_cleaner/readme.txt
+++ b/scripts/helper_scripts/shed_tool_conf_xml_cleaner/readme.txt
@@ -1,0 +1,12 @@
+(.venv) chris@artbio:~/shed_tool_conf_xml_cleaner$ which python && python --version && pip list
+
+/home/chris/shed_tool_conf_xml_cleaner/.venv/bin/python
+
+Python 3.8.10
+
+Package       Version
+------------- -------
+pip           20.0.2
+pkg-resources 0.0.0
+setuptools    44.0.0
+wheel         0.34.2

--- a/scripts/helper_scripts/shed_tool_conf_xml_cleaner/shed_tool_conf_xml_cleaner.py
+++ b/scripts/helper_scripts/shed_tool_conf_xml_cleaner/shed_tool_conf_xml_cleaner.py
@@ -3,10 +3,10 @@
 #     -i shed_tool_conf.xml
 #     -o shed_tool_conf.xml
 
-from xml.dom import minidom
 import xml.etree.ElementTree as ET
 from argparse import ArgumentParser
 from argparse import RawTextHelpFormatter
+from xml.dom import minidom
 
 
 def merge_xml_sections(input_file, output_file):

--- a/scripts/helper_scripts/shed_tool_conf_xml_cleaner/shed_tool_conf_xml_cleaner.py
+++ b/scripts/helper_scripts/shed_tool_conf_xml_cleaner/shed_tool_conf_xml_cleaner.py
@@ -15,7 +15,7 @@ def merge_xml_sections(input_file, output_file):
     tool_counter = 0
     tree = ET.parse(input_file)
     root = tree.getroot()
-    children = root.getchildren()
+    children = list(root)
     section_list = []
     for child in children:
         initial_section_number += 1
@@ -42,7 +42,7 @@ def merge_xml_sections(input_file, output_file):
                         tool = ET.SubElement(child, "tool",
                                              file=item.attrib['file'],
                                              guid=item.attrib['guid'])
-                    for subitem in item.getchildren():
+                    for subitem in list(item):
                         buffer = ET.SubElement(tool, subitem.tag)
                         buffer.text = subitem.text
     newtree = ET.ElementTree(toolbox)


### PR DESCRIPTION
the getchildren() method was deprecated and is replace by a simple list()