### PR TITLE
Upgrade guppy tool wrapper for apt (ubuntu) version 6.5.7

### DIFF
--- a/tools/guppy/guppy_basecaller.xml
+++ b/tools/guppy/guppy_basecaller.xml
@@ -25,6 +25,10 @@
     <outputs>
         <data name="output_fastq" format="fastqsanger" label="Guppy base calling" />
     </outputs>
+    <tests>
+        <test>
+        </test>
+    </tests>
     <help><![CDATA[
         A wrapper for guppy basecaller. This expects two type of inputs: a collection of fast5 files,
         and a configuration in the form of a tar file.

--- a/tools/guppy/guppy_basecaller.xml
+++ b/tools/guppy/guppy_basecaller.xml
@@ -14,7 +14,7 @@
                          --config *.cfg
                          --num_callers \${GALAXY_SLOTS:-2}
                          --records_per_fastq 0
-                         --cpu_threads_per_caller \${GALAXY_SLOTS:-2}
+                         --cpu_threads_per_caller 1
                          --disable_pings
         && cat out/pass/*.fastq | awk '{ if (NR%4 == 2) {gsub(/U/,"T",$1); print $1} else print }' > $output_fastq
         && echo "guppy must be installed system-wide from ONT linux packages" > $discloser 

--- a/tools/guppy/guppy_basecaller.xml
+++ b/tools/guppy/guppy_basecaller.xml
@@ -17,6 +17,7 @@
                          --cpu_threads_per_caller \${GALAXY_SLOTS:-2}
                          --disable_pings
         && cat out/pass/*.fastq | awk '{ if (NR%4 == 2) {gsub(/U/,"T",$1); print $1} else print }' > $output_fastq
+        && echo "guppy must be installed system-wide from ONT linux packages" > $discloser 
     ]]></command>
     <inputs>
         <param name="infiles" type="data_collection" format="h5" label="Fast5 input (datatype h5)" multiple="true"/>
@@ -24,11 +25,8 @@
     </inputs>
     <outputs>
         <data name="output_fastq" format="fastqsanger" label="Guppy base calling" />
+        <data name="discloser" format="txt" label="Guppy Discloser" />
     </outputs>
-    <tests>
-        <test>
-        </test>
-    </tests>
     <help><![CDATA[
         A wrapper for guppy basecaller. This expects two type of inputs: a collection of fast5 files,
         and a configuration in the form of a tar file.

--- a/tools/guppy/guppy_basecaller.xml
+++ b/tools/guppy/guppy_basecaller.xml
@@ -1,4 +1,4 @@
-<tool id="guppy-basecaller" name="Guppy basecaller wrapper" version="0.2.2" python_template_version="3.8">
+<tool id="guppy-basecaller" name="Guppy basecaller wrapper" version="6.5.7+galaxy0" profile="23.0">
     <description>A simple wrapper for guppy basecaller that depends on configuration files</description>
     <requirements>
     </requirements>
@@ -9,23 +9,21 @@
         #end for
         tar xf $config &&
         guppy_basecaller -i .
-                         --save_path out
-                         --data_path .
+                         --save_path "out"
+                         --data_path "."
                          --config *.cfg
-                         --num_callers 4
+                         --num_callers \${GALAXY_SLOTS:-2}
                          --records_per_fastq 0
                          --cpu_threads_per_caller \${GALAXY_SLOTS:-2}
                          --disable_pings
-###                         --qscore_filtering
-###                         --calib_detect
-        && cat out/*.fastq | awk '{ if (NR%4 == 2) {gsub(/U/,"T",$1); print $1} else print }' > $output_fastq
+        && cat out/pass/*.fastq | awk '{ if (NR%4 == 2) {gsub(/U/,"T",$1); print $1} else print }' > $output_fastq
     ]]></command>
     <inputs>
         <param name="infiles" type="data_collection" format="h5" label="Fast5 input (datatype h5)" multiple="true"/>
         <param name="config" type="data" format="tar" label="Guppy basecall configuration model"/>
     </inputs>
     <outputs>
-        <data name="output_fastq" format="fastqsanger" />
+        <data name="output_fastq" format="fastqsanger" label="Guppy base calling" />
     </outputs>
     <help><![CDATA[
         A wrapper for guppy basecaller. This expects two type of inputs: a collection of fast5 files,


### PR DESCRIPTION
Change the path of output from "out" to "out/pass"

### Note that this tool is developed outside of the normal tools-artbio workflow. guppy_basecaller must be installed system wide from ONT linux package repository. Therefore it is not tested and does not contain tests section.