### PR TITLE
drop ubuntu 20.04 for latest

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -185,7 +185,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         r-version: ['release']
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Use of 20.04 for CI is dropped. upgrading to ubuntu-latest