### PR TITLE
refactor(snp_pileup): Implement balanced region-based parallelization

### DIFF
--- a/tools/facets/macros.xml
+++ b/tools/facets/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@pipefail@"><![CDATA[set -o | grep -q pipefail && set -o pipefail;]]></token>
     <token name="@TOOL_VERSION@">0.6.2</token>
-    <token name="@VERSION_SUFFIX@">7</token>
+    <token name="@VERSION_SUFFIX@">8</token>
     <token name="@PROFILE@">23.0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/facets/snp_pileup_for_facets_wrapper.sh
+++ b/tools/facets/snp_pileup_for_facets_wrapper.sh
@@ -89,7 +89,7 @@ NUM_CHUNKS=$((nprocs * 10))
 BAM_CONTIGS=$("${SAMTOOLS_EXE}" view -H "$normal_bam" | awk -F'\t' '/^@SQ/ {print $2}' | sed 's/SN://')
 
 # Get contigs from VCF header
-VCF_CONTIGS=$("${BCFTOOLS_EXE}" index --sequence-names "$snp_vcf")
+VCF_CONTIGS=$("${BCFTOOLS_EXE}" query -l "$snp_vcf")
 
 # Find the intersection of the two lists, then filter for primary chromosomes.
 # 'comm -12' prints lines common to both sorted files.


### PR DESCRIPTION
This pull request refactors the parallelization logic within the `snp_pileup_for_facets_wrapper.sh` script to improve performance and resource utilization.

### Motivation

The previous strategy of parallelizing on a per-chromosome basis resulted in an imbalanced workload. The significant size difference between chromosomes created a "long pole" problem, where the total runtime was dictated by the time required to process the largest chromosome, leading to inefficient use of CPU cores.

### New Strategy: Region-Based Chunking

This commit changes the parallelization model from a biological division (chromosomes) to a computational one (chunks):

1.  **Chromosome Discovery:** The script first determines the set of primary chromosomes (autosomes and sex chromosomes) present in the provided reference VCF.
2.  **Region Generation:** This set of chromosomes is then divided into a large number of smaller, roughly equal-sized genomic regions (`chr:start-end`). The number of these "chunks" is set as a multiple of the requested threads to ensure a deep task queue for the scheduler.
3.  **Dynamic Distribution:** `GNU Parallel` distributes this list of numerous small regions dynamically to the available threads. When a thread finishes a small chunk, it immediately receives the next available one from the queue.

### Benefits

This approach ensures a significantly more balanced workload across all allocated cores. It mitigates the previous bottleneck, leading to improved overall performance and more efficient use of computational resources, especially for analyses with a high thread count.